### PR TITLE
GIT_MODEL_HASH is the wrong word

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8
 EXPOSE 8080
 EXPOSE 5050
 
-ENV GIT_MODEL_HASH $GIT_MODEL_HASH
+ENV GIT_HASH $GIT_HASH
 
 RUN mkdir /leonardo
 COPY ./leonardo*.jar /leonardo

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -18,11 +18,11 @@ function make_jar()
     # start test db
     bash ./docker/run-mysql.sh start ${PROJECT}
 
-    # Get the last commit hash of the model directory and set it as an environment variable
-    GIT_MODEL_HASH=$(git log -n 1 --pretty=format:%h)
+    # Get the last commit hash and set it as an environment variable
+    GIT_HASH=$(git log -n 1 --pretty=format:%h)
 
     # make jar.  cache sbt dependencies.
-    JAR_CMD=`docker run --rm --link mysql:mysql -e GIT_MODEL_HASH=$GIT_MODEL_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 broadinstitute/scala-baseimage /working/docker/install.sh /working`
+    JAR_CMD=`docker run --rm --link mysql:mysql -e GIT_HASH=$GIT_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 broadinstitute/scala-baseimage /working/docker/install.sh /working`
     EXIT_CODE=$?
  
     # stop test db

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -51,6 +51,8 @@ object Settings {
   val rootSettings = commonSettings ++ List(
     name := "leonardo",
     libraryDependencies ++= rootDependencies
+    //the version is applied in rootVersionSettings and is set to 0.1-githash.
+    //we don't really use it for anything but we might when we publish our model
   ) ++ commonAssemblySettings ++ rootVersionSettings
 
 

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -3,16 +3,16 @@ import sbt._
 
 
 object Version {
-  val baseModelVersion = "0.1"
+  val baseVersion = "0.1"
 
   def getVersionString = {
-    def getLastModelCommitFromGit = { s"""git rev-parse --short HEAD""" !! }
+    def getLastCommitFromGit = { s"""git rev-parse --short HEAD""" !! }
 
     // either specify git model hash as an env var or derive it
     // if building from the broadinstitute/scala-baseimage docker image use env var
     // (scala-baseimage doesn't have git in it)
-    val lastModelCommit = sys.env.getOrElse("GIT_MODEL_HASH", getLastModelCommitFromGit ).trim()
-    val version = baseModelVersion + "-" + lastModelCommit
+    val lastCommit = sys.env.getOrElse("GIT_HASH", getLastCommitFromGit ).trim()
+    val version = baseVersion + "-" + lastCommit
 
     // The project isSnapshot string passed in via command line settings, if desired.
     val isSnapshot = sys.props.getOrElse("project.isSnapshot", "true").toBoolean


### PR DESCRIPTION
GIT_MODEL_HASH is a holdover from rawls publishing rawlsModel and is confused.