### PR TITLE
[GAWB-2498] Notebook Service: poll Dataproc to get cluster IP

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,8 @@ object Dependencies {
   val googleDataproc: ModuleID =    "com.google.apis"     % "google-api-services-dataproc" % s"v1-rev53-$googleV" excludeAll(excludeGuavaJDK5)
   val googleRpc: ModuleID = "io.grpc" % "grpc-core" % "1.5.0"
 
-  val scalaTest: ModuleID = "org.scalatest" %% "scalatest" % scalaTestV % "test"
+  val scalaTest: ModuleID = "org.scalatest" %% "scalatest"    % scalaTestV % "test"
+  val mockito: ModuleID =   "org.mockito"    % "mockito-core" % "2.7.22"   % "test"
 
   // All of workbench-libs pull in Akka; exclude it since we provide our own Akka dependency.
   // workbench-google pulls in workbench-{util, model, metrics}; exclude them so we can control the library versions individually.
@@ -80,6 +81,7 @@ object Dependencies {
     googleRpc,
 
     scalaTest,
+    mockito,
 
     slick,
     hikariCP,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,6 +39,7 @@ object Dependencies {
   val akkaHttpTestKit: ModuleID =   "com.typesafe.akka"   %%  "akka-http-testkit"    % akkaHttpV % "test"
 
   val googleDataproc: ModuleID =    "com.google.apis"     % "google-api-services-dataproc" % s"v1-rev53-$googleV" excludeAll(excludeGuavaJDK5)
+  val googleRpc: ModuleID = "io.grpc" % "grpc-core" % "1.5.0"
 
   val scalaTest: ModuleID = "org.scalatest" %% "scalatest" % scalaTestV % "test"
 
@@ -76,6 +77,7 @@ object Dependencies {
     akkaHttpTestKit,
 
     googleDataproc,
+    googleRpc,
 
     scalaTest,
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,6 +39,7 @@ object Dependencies {
   val akkaHttpTestKit: ModuleID =   "com.typesafe.akka"   %%  "akka-http-testkit"    % akkaHttpV % "test"
 
   val googleDataproc: ModuleID =    "com.google.apis"     % "google-api-services-dataproc" % s"v1-rev53-$googleV" excludeAll(excludeGuavaJDK5)
+  
   val googleRpc: ModuleID = "io.grpc" % "grpc-core" % "1.5.0"
 
   val scalaTest: ModuleID = "org.scalatest" %% "scalatest"    % scalaTestV % "test"

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -126,6 +126,35 @@ paths:
             - openid
             - email
             - profile
+    delete:
+      summary: Deletes an existing dataproc cluster in the given project
+      description: deletes a dataproc cluster
+      operationId: deleteCluster
+      tags:
+        - cluster
+      parameters:
+        - in: path
+          name: googleProject
+          description: googleProject
+          required: true
+          type: string
+        - in: path
+          name: clusterName
+          description: clusterName
+          required: true
+          type: string
+      responses:
+        '202':
+          description: Cluster deletion request accepted
+        '404':
+          description: Cluster not found
+          schema:
+            $ref: '#/definitions/ErrorReport'
+        '500':
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+
   '/api/notebooks/{googleProject}/{clusterName}':
     get:
       summary: Access Jupyter notebooks on a dataproc cluster
@@ -164,34 +193,6 @@ paths:
             - openid
             - email
             - profile
-    delete:
-      summary: Deletes an existing dataproc cluster in the given project
-      description: deletes a dataproc cluster
-      operationId: deleteCluster
-      tags:
-        - cluster
-      parameters:
-        - in: path
-          name: googleProject
-          description: googleProject
-          required: true
-          type: string
-        - in: path
-          name: clusterName
-          description: clusterName
-          required: true
-          type: string
-      responses:
-        '202':
-          description: Cluster deletion request accepted
-        '404':
-          description: Cluster not found
-          schema:
-            $ref: '#/definitions/ErrorReport'
-        '500':
-          description: Internal Error
-          schema:
-            $ref: '#/definitions/ErrorReport'
 ##########################################################################################
 ## DEFINITIONS
 ##########################################################################################

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -11,6 +11,7 @@ import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.dns.ClusterDnsCache
 import org.broadinstitute.dsde.workbench.leonardo.config.{DataprocConfig, ProxyConfig, SwaggerConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.GoogleDataprocDAO
+import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor
 import org.broadinstitute.dsde.workbench.leonardo.service.{LeonardoService, ProxyService}
 
 object Boot extends App with LazyLogging {
@@ -44,7 +45,8 @@ object Boot extends App with LazyLogging {
     }
 
     val gdDAO = new GoogleDataprocDAO(dataprocConfig)
-    val leonardoService = new LeonardoService(gdDAO, dbRef)
+    val clusterMonitorSupervisor = system.actorOf(ClusterMonitorSupervisor.props(gdDAO, dbRef))
+    val leonardoService = new LeonardoService(gdDAO, dbRef, clusterMonitorSupervisor)
     val clusterDnsCache = system.actorOf(ClusterDnsCache.props(proxyConfig, dbRef))
     val proxyService = new ProxyService(proxyConfig, dbRef, clusterDnsCache)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -56,7 +56,7 @@ object Boot extends App with LazyLogging {
     val proxyService = new ProxyService(proxyConfig, dbRef, clusterDnsCache)
     val leoRoutes = new LeoRoutes(leonardoService, proxyService, config.as[SwaggerConfig]("swagger"))
 
-    startClusterMontitors(dbRef, clusterMonitorSupervisor)
+    startClusterMonitors(dbRef, clusterMonitorSupervisor)
 
     Http().bindAndHandle(leoRoutes.route, "0.0.0.0", 8080)
       .recover {
@@ -66,7 +66,7 @@ object Boot extends App with LazyLogging {
       }
   }
 
-  def startClusterMontitors(dbRef: DbReference, clusterMonitor: ActorRef)(implicit executionContext: ExecutionContext) = {
+  private def startClusterMonitors(dbRef: DbReference, clusterMonitor: ActorRef)(implicit executionContext: ExecutionContext) = {
     dbRef.inTransaction { dataAccess =>
       dataAccess.clusterQuery.listPending.map { clusters =>
         clusters.foreach { cluster =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.leonardo.config
 
 case class DataprocConfig(serviceAccount: String,
                           dataprocInitScriptURI: String,
-                          dataprocDefaultZone: String,
+                          dataprocDefaultRegion: String,
                           dataprocDockerImage: String,
                           serviceAccountPemPath: String,
                           clusterUrlBase: String)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/MonitorConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/MonitorConfig.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.dsde.workbench.leonardo.config
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * Created by rtitle on 9/6/17.
+  */
+case class MonitorConfig(pollPeriod: FiniteDuration,
+                         maxRetries: Int = -1,
+                         canRecreateCluster: Boolean = true)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
@@ -16,7 +16,7 @@ package object config {
   implicit val dataprocConfigReader: ValueReader[DataprocConfig] = ValueReader.relative { config =>
     DataprocConfig(config.getString("serviceAccount"),
       config.getString("dataprocInitScriptURI"),
-      config.getString("dataprocDefaultZone"),
+      config.getString("dataprocDefaultRegion"),
       config.getString("dataprocDockerImage"),
       config.getString("pathToLeonardoPem"),
       config.getString("clusterUrlBase"))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
@@ -29,4 +29,8 @@ package object config {
   implicit val proxyConfigReader: ValueReader[ProxyConfig] = ValueReader.relative { config =>
     ProxyConfig(config.getInt("jupyterPort"), config.getString("jupyterDomain"), toScalaDuration(config.getDuration("dnsPollPeriod")))
   }
+
+  implicit val monitorConfigReader: ValueReader[MonitorConfig] = ValueReader.relative { config =>
+    MonitorConfig(toScalaDuration(config.getDuration("pollPeriod")), config.getInt("maxRetries"), config.getBoolean("canRecreateCluster"))
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DataprocDAO.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
-import com.google.api.services.dataproc.model.Operation
+import com.google.api.services.compute.model.Instance
+import com.google.api.services.dataproc.model.{Cluster, Operation}
+import org.broadinstitute.dsde.workbench.leonardo.model.ModelTypes.GoogleProject
 import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterRequest, ClusterResponse}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -9,4 +11,10 @@ trait DataprocDAO {
   def createCluster(googleProject: String, clusterName: String, clusterRequest: ClusterRequest)(implicit executionContext: ExecutionContext): Future[ClusterResponse]
 
   def deleteCluster(googleProject: String, clusterName: String)(implicit executionContext: ExecutionContext): Future[Unit]
+
+  def getCluster(googleProject: GoogleProject, clusterName: String)(implicit executionContext: ExecutionContext): Future[Cluster]
+
+  def getOperation(operationName: String): Future[Operation]
+
+  def getInstance(googleProject: GoogleProject, instanceName: String): Future[Instance]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DataprocDAO.scala
@@ -10,11 +10,11 @@ import scala.concurrent.{ExecutionContext, Future}
 trait DataprocDAO {
   def createCluster(googleProject: String, clusterName: String, clusterRequest: ClusterRequest)(implicit executionContext: ExecutionContext): Future[ClusterResponse]
 
-  def deleteCluster(googleProject: String, clusterName: String)(implicit executionContext: ExecutionContext): Future[Unit]
+  def deleteCluster(googleProject: String, clusterName: String)(implicit executionContext: ExecutionContext): Future[Option[Operation]]
 
   def getCluster(googleProject: GoogleProject, clusterName: String)(implicit executionContext: ExecutionContext): Future[Cluster]
 
-  def getOperation(operationName: String): Future[Operation]
+  def getOperation(operationName: String)(implicit executionContext: ExecutionContext): Future[Operation]
 
-  def getInstance(googleProject: GoogleProject, instanceName: String): Future[Instance]
+  def getInstance(googleProject: GoogleProject, instanceName: String)(implicit executionContext: ExecutionContext): Future[Instance]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DataprocDAO.scala
@@ -16,5 +16,5 @@ trait DataprocDAO {
 
   def getOperation(operationName: String)(implicit executionContext: ExecutionContext): Future[Operation]
 
-  def getInstance(googleProject: GoogleProject, instanceName: String)(implicit executionContext: ExecutionContext): Future[Instance]
+  def getInstance(googleProject: GoogleProject, zone: String, instanceName: String)(implicit executionContext: ExecutionContext): Future[Instance]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
@@ -116,9 +116,9 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig)(implicit v
     }
   }
 
-  override def getInstance(googleProject: GoogleProject, instanceName: String)(implicit executionContext: ExecutionContext): Future[Instance] = {
+  override def getInstance(googleProject: GoogleProject, zone: String, instanceName: String)(implicit executionContext: ExecutionContext): Future[Instance] = {
     Future {
-      val request = compute.instances().get(googleProject, dataprocConfig.dataprocDefaultZone, instanceName)
+      val request = compute.instances().get(googleProject, zone, instanceName)
       try {
         executeGoogleRequest(request)
       } catch {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
@@ -111,7 +111,7 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig)(implicit v
         executeGoogleRequest(request)
       } catch {
         case e: GoogleJsonResponseException =>
-          throw CallToGoogleApiFailedException("", "", e.getStatusCode, e.getDetails.getMessage)
+          throw CallToGoogleApiFailedException("operation", operationName, e.getStatusCode, e.getDetails.getMessage)
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
@@ -69,7 +69,7 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig)(implicit v
       val initActions = Seq(new NodeInitializationAction().setExecutableFile(dataprocConfig.dataprocInitScriptURI))
       val clusterConfig = new ClusterConfig().setGceClusterConfig(gce).setInitializationActions(initActions.asJava)
       val cluster = new Cluster().setClusterName(clusterName).setConfig(clusterConfig)
-      val request = dataproc.projects().regions().clusters().create(googleProject, dataprocConfig.dataprocDefaultZone, cluster)
+      val request = dataproc.projects().regions().clusters().create(googleProject, dataprocConfig.dataprocDefaultRegion, cluster)
       try {
         executeGoogleRequest(request)
       } catch {
@@ -81,7 +81,7 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig)(implicit v
   def deleteCluster(googleProject: String, clusterName: String)(implicit executionContext: ExecutionContext): Future[Option[Operation]] = {
     Future {
       //currently, the bucketPath of the clusterRequest are not used - it will be used later as a place to store notebooks and results
-      val request = dataproc.projects().regions().clusters().delete(googleProject, dataprocConfig.dataprocDefaultZone, clusterName)
+      val request = dataproc.projects().regions().clusters().delete(googleProject, dataprocConfig.dataprocDefaultRegion, clusterName)
       try {
         Some(executeGoogleRequest(request))
       } catch {
@@ -94,7 +94,7 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig)(implicit v
 
   override def getCluster(googleProject: GoogleProject, clusterName: String)(implicit executionContext: ExecutionContext): Future[Cluster] = {
     Future {
-      val request = dataproc.projects().regions().clusters().get(googleProject, dataprocConfig.dataprocDefaultZone, clusterName)
+      val request = dataproc.projects().regions().clusters().get(googleProject, dataprocConfig.dataprocDefaultRegion, clusterName)
       try {
         executeGoogleRequest(request)
       } catch {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -77,7 +77,7 @@ trait ClusterComponent extends LeoComponent {
       }
     }
 
-    def deleteCluster(googleId: UUID):DBIO[Int] = {
+    def deleteCluster(googleId: UUID): DBIO[Int] = {
       clusterQuery.filter(_.googleId === googleId)
         .map(c => (c.destroyedDate, c.status))
         .update((Option(Timestamp.from(java.time.Instant.now())), ClusterStatus.Deleting.toString))
@@ -85,6 +85,16 @@ trait ClusterComponent extends LeoComponent {
 
     def updateClusterStatus(googleId: UUID, newStatus: ClusterStatus): DBIO[Int] = {
       clusterQuery.filter { _.googleId === googleId }.map(_.status).update(newStatus.toString)
+    }
+
+    def updateClusterOperation(googleId: UUID, newOperation: Option[String]): DBIO[Int] = {
+      newOperation.map { op =>
+        clusterQuery.filter { _.googleId === googleId }.map(_.operationName).update(op)
+      }.getOrElse(DBIO.successful(0))
+    }
+
+    def updateClusterName(googleId: UUID, newName: String): DBIO[Int] = {
+      clusterQuery.filter { _.googleId === googleId }.map(_.clusterName).update(newName)
     }
 
     def getIdByGoogleId(googleId: UUID): DBIO[Option[Long]] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -87,6 +87,7 @@ trait ClusterComponent extends LeoComponent {
 
     def deleteCluster(googleId: UUID, newOperation: Option[String]): DBIO[Int] = {
       val query = clusterQuery.filter(_.googleId === googleId)
+      // Update the operation name if we have one
       newOperation match {
         case Some(op) =>
           query.map(c => (c.destroyedDate, c.status, c.operationName))
@@ -99,7 +100,7 @@ trait ClusterComponent extends LeoComponent {
 
     def completeDeletion(googleId: UUID, clusterName: String): DBIO[Int] = {
       updateClusterStatus(googleId, ClusterStatus.Deleted) andThen
-        // Append a random suffix to the cluster name to prevent unique key conflicts in the database in case a cluster
+        // Append a random suffix to the cluster name to prevent unique key conflicts in case a cluster
         // with the same name is recreated.
         // TODO: This is a bit ugly; a better solution would be to have a unique key on (googleId, clusterName, deletedAt)
         updateClusterName(googleId, appendRandomSuffix(clusterName))
@@ -169,8 +170,8 @@ trait ClusterComponent extends LeoComponent {
       )
     }
 
-    private def appendRandomSuffix(str: String): String = {
-      s"${str}_${Random.alphanumeric.take(6).mkString}"
+    private def appendRandomSuffix(str: String, n: Int = 6): String = {
+      s"${str}_${Random.alphanumeric.take(n).mkString}"
     }
 
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -63,6 +63,12 @@ trait ClusterComponent extends LeoComponent {
       }
     }
 
+    def listPending(): DBIO[Seq[Cluster]] = {
+      clusterQueryWithLabels.filter { _._1.status inSetBind ClusterStatus.pendingStatuses.map(_.toString) }.result map { recs =>
+        unmarshalClustersWithLabels(recs)
+      }
+    }
+
     // currently any string can be a GoogleProject
     // but I'm planning to fix that soon
     def getByName(project: GoogleProject, name: String): DBIO[Option[Cluster]] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -7,6 +7,8 @@ import java.util.UUID
 import org.broadinstitute.dsde.workbench.leonardo.model.ModelTypes.GoogleProject
 import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, ClusterStatus}
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterStatus._
+import slick.dbio.Effect
+import slick.sql.FixedSqlAction
 
 case class ClusterRecord(id: Long,
                          clusterName: String,
@@ -76,16 +78,23 @@ trait ClusterComponent extends LeoComponent {
     }
 
     def deleteCluster(googleId: UUID):DBIO[Int] = {
-       clusterQuery.filter(_.googleId === googleId)
-         .map(c => (c.destroyedDate, c.status))
-         .update((Option(Timestamp.from(java.time.Instant.now())), ClusterStatus.Deleting.toString))
+      clusterQuery.filter(_.googleId === googleId)
+        .map(c => (c.destroyedDate, c.status))
+        .update((Option(Timestamp.from(java.time.Instant.now())), ClusterStatus.Deleting.toString))
+    }
 
+    def updateClusterStatus(googleId: UUID, newStatus: ClusterStatus): DBIO[Int] = {
+      clusterQuery.filter { _.googleId === googleId }.map(_.status).update(newStatus.toString)
     }
 
     def getIdByGoogleId(googleId: UUID): DBIO[Option[Long]] = {
       clusterQuery.filter { _.googleId === googleId }.result map { recs =>
         recs.headOption map { _.id }
       }
+    }
+
+    def updateIpByGoogleId(googleId: UUID, newIp: String): DBIO[Int] = {
+      clusterQuery.filter(_.googleId === googleId).map(_.hostIp).update(Some(newIp))
     }
 
     private def marshalCluster(cluster: Cluster): ClusterRecord = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -23,10 +23,12 @@ object ModelTypes {
 object ClusterStatus extends Enumeration {
   type ClusterStatus = Value
   val Unknown, Creating, Running, Updating, Error, Deleting, Deleted = Value
-  val activeStatuses = Seq(Unknown, Creating, Updating)
+  val activeStatuses = Set(Unknown, Creating, Running, Updating)
+  val pendingStatuses = Set(Unknown, Creating, Updating, Deleting)
 
   class StatusValue(status: ClusterStatus) {
-    def isActive:Boolean = activeStatuses contains status
+    def isActive: Boolean = activeStatuses contains status
+    def isPending: Boolean = pendingStatuses contains status
   }
   implicit def enumConvert(status: ClusterStatus): StatusValue = new StatusValue(status)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -10,6 +10,7 @@ import org.broadinstitute.dsde.workbench.leonardo.config.DataprocConfig
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterStatus.ClusterStatus
 import org.broadinstitute.dsde.workbench.leonardo.model.ModelTypes.{GoogleBucket, GoogleProject, GoogleServiceAccount}
 import spray.json.{DefaultJsonProtocol, DeserializationException, JsString, JsValue, JsonFormat}
+
 import scala.language.implicitConversions
 
 // maybe we want to get fancy later
@@ -21,15 +22,19 @@ object ModelTypes {
 
 object ClusterStatus extends Enumeration {
   type ClusterStatus = Value
-  val Unknown, Creating, Deleting, Deleted = Value
-  val activeStatuses = Seq(Unknown, Creating)
+  val Unknown, Creating, Running, Updating, Error, Deleting, Deleted = Value
+  val activeStatuses = Seq(Unknown, Creating, Updating)
 
-  class StatusValue(status: Value) {
+  class StatusValue(status: ClusterStatus) {
     def isActive:Boolean = activeStatuses contains status
   }
-  implicit def enumConvert(status: Value): StatusValue = new StatusValue(status)
+  implicit def enumConvert(status: ClusterStatus): StatusValue = new StatusValue(status)
 
-  def withNameOpt(s: String): Option[Value] = values.find(_.toString == s)
+  def withNameOpt(s: String): Option[ClusterStatus] = values.find(_.toString == s)
+
+  def withNameIgnoreCase(str: String): Option[ClusterStatus] = {
+    values.find(_.toString.equalsIgnoreCase(str))
+  }
 }
 
 object Cluster {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -8,6 +8,7 @@ import com.google.api.services.compute.model.Instance
 import com.google.api.services.dataproc.model.{Operation, Cluster => GoogleCluster}
 import com.typesafe.scalalogging.LazyLogging
 import io.grpc.Status.Code
+import org.broadinstitute.dsde.workbench.leonardo.config.MonitorConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.DataprocDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterStatus._
@@ -21,23 +22,36 @@ import scala.concurrent.duration._
 import scala.util.Failure
 
 object ClusterMonitorActor {
-  def props(cluster: Cluster, gdDAO: DataprocDAO, dbRef: DbReference): Props =
-    Props(new ClusterMonitorActor(cluster, gdDAO, dbRef))
+  /**
+    * Creates a Props object used for creating a {{{ClusterMonitorActor}}}.
+    */
+  def props(cluster: Cluster, monitorConfig: MonitorConfig, gdDAO: DataprocDAO, dbRef: DbReference): Props =
+    Props(new ClusterMonitorActor(cluster, monitorConfig, gdDAO, dbRef))
 
-  sealed trait ClusterMonitorMessage extends Product with Serializable
-  case class ScheduleMonitorPass() extends ClusterMonitorMessage
-  case class StartMonitorPass() extends ClusterMonitorMessage
-  case class ReadyCluster(publicIP: String) extends ClusterMonitorMessage
-  case class NotReadyCluster(status: ClusterStatus) extends ClusterMonitorMessage
-  case class FailedCluster(code: Int, message: Option[String]) extends ClusterMonitorMessage
-  case class DeletedCluster() extends ClusterMonitorMessage
-  case class ShutdownActor(notifyParentMsg: Option[Any] = None) extends ClusterMonitorMessage
+  // ClusterMonitorActor messages:
 
+  private[monitor] sealed trait ClusterMonitorMessage extends Product with Serializable
+  private[monitor] case class ScheduleMonitorPass() extends ClusterMonitorMessage
+  private[monitor] case class QueryForCluster() extends ClusterMonitorMessage
+  private[monitor] case class ReadyCluster(publicIP: String) extends ClusterMonitorMessage
+  private[monitor] case class NotReadyCluster(status: ClusterStatus) extends ClusterMonitorMessage
+  private[monitor] case class FailedCluster(code: Int, message: Option[String]) extends ClusterMonitorMessage
+  private[monitor] case class DeletedCluster() extends ClusterMonitorMessage
+  private[monitor] case class ShutdownActor(notifyParentMsg: Option[Any] = None) extends ClusterMonitorMessage
+
+  /** Used for tracking internal exceptions in ClusterMonitorActor. This exception is not returned to users. */
   private[monitor] case class ClusterMonitorException(errMsg: String) extends LeoException(errMsg)
-
 }
 
+/**
+  * An actor which monitors the status of a Cluster. Periodically queries Google for the cluster status,
+  * and acts appropriately for Running, Deleted, and Failed clusters.
+  * @param cluster the Cluster to monitor
+  * @param gdDAO the Google dataproc DAO
+  * @param dbRef the DB reference
+  */
 class ClusterMonitorActor(val cluster: Cluster,
+                          val monitorConfig: MonitorConfig,
                           val gdDAO: DataprocDAO,
                           val dbRef: DbReference) extends Actor with LazyLogging {
   import context._
@@ -48,61 +62,82 @@ class ClusterMonitorActor(val cluster: Cluster,
   }
 
   override def receive: Receive = {
-    case Right(ScheduleMonitorPass) =>
-      scheduleMonitorPass
+    case Right(msg) =>
+      logger.debug(s"Received message $msg")
 
-    case Right(StartMonitorPass) =>
-      getGoogleCluster.value pipeTo self
-
-    case Right(NotReadyCluster(status)) =>
-      handleNotReadyCluster(status).value pipeTo self
-
-    case Right(ReadyCluster(ip)) =>
-      handleReadyCluster(ip).value pipeTo self
-
-    case Right(FailedCluster(code, message)) =>
-      handleFailedCluster(code, message).value pipeTo self
-
-    case Right(DeletedCluster) =>
-      handleDeletedCluster().value pipeTo self
-
-    case Right(ShutdownActor(notifyParentMsg)) =>
-      notifyParentMsg.foreach(msg => parent ! msg)
-      stop(self)
+      msg match {
+        case ScheduleMonitorPass() => scheduleMonitorPass
+        case QueryForCluster() => getGoogleCluster.value pipeTo self
+        case NotReadyCluster(status) => handleNotReadyCluster(status).value pipeTo self
+        case ReadyCluster(ip) => handleReadyCluster(ip).value pipeTo self
+        case FailedCluster(code, message) => handleFailedCluster(code, message).value pipeTo self
+        case DeletedCluster() => handleDeletedCluster.value pipeTo self
+        case ShutdownActor(notifyParentMsg) =>
+          notifyParentMsg.foreach(msg => parent ! msg)
+          stop(self)
+      }
 
     case Left(exception: Throwable) =>
+      // An error occurred, let the supervisor handle it
       logger.error("Error occurred in ClusterMonitorActor", exception)
       throw exception
 
     case Failure(exception) =>
+      // Shouldn't really happen as all Futures are lifted into EitherT.
+      // But take the same action anyway.
       logger.error("Error occurred in ClusterMonitorActor", exception)
       throw exception
   }
 
-  def scheduleMonitorPass: Unit = {
-    context.system.scheduler.scheduleOnce(1 minute, self, Right(StartMonitorPass))
+  private def scheduleMonitorPass: Unit = {
+    system.scheduler.scheduleOnce(monitorConfig.pollPeriod, self, Right(QueryForCluster()))
   }
 
+  /**
+    * Handles a dataproc cluster which is not ready yet. We don't take any action, just
+    * schedule another monitor pass.
+    * @param status the Google status
+    * @return error or ScheduleMonitorPass
+    */
   private def handleNotReadyCluster(status: ClusterStatus): EitherT[Future, Throwable, ScheduleMonitorPass] = {
-    for {
-      _ <- dbRef.inTransaction(_.clusterQuery.updateClusterStatus(cluster.googleId, status)).attemptT
-    } yield ScheduleMonitorPass()
+    Future.successful(ScheduleMonitorPass()).attemptT
   }
 
+  /**
+    * Handles a dataproc cluster which is ready. We update the status and IP in the database,
+    * then shut down this actor.
+    * @param publicIp the cluster public IP, according to Google
+    * @return error or ShutdownActor
+    */
   private def handleReadyCluster(publicIp: String): EitherT[Future, Throwable, ShutdownActor] = {
+    logger.info(s"Cluster ${cluster.googleProject}/${cluster.clusterName} is ready for use!")
     dbRef.inTransaction { dataAccess =>
       dataAccess.clusterQuery.updateClusterStatus(cluster.googleId, ClusterStatus.Running) andThen
         dataAccess.clusterQuery.updateIpByGoogleId(cluster.googleId, publicIp)
     }.map(_ => ShutdownActor()).attemptT
   }
 
+  /**
+    * Handles a dataproc cluster which has failed. We update the status to Error in the database, and
+    * shut down this actor. Depending on the status code from Google, we might try to delete
+    * and recreate the cluster.
+    * @param code Google error code
+    * @param message Google error message
+    * @return error or ShutdownActor
+    */
   private def handleFailedCluster(code: Int, message: Option[String]): EitherT[Future, Throwable, ShutdownActor] = {
     dbRef.inTransaction(_.clusterQuery.updateClusterStatus(cluster.googleId, ClusterStatus.Error)).attemptT.flatMap { _ =>
       val future = if (shouldRecreateCluster(code, message)) {
-        gdDAO.deleteCluster(cluster.googleProject, cluster.clusterName).map { _ =>
-          ShutdownActor(Some(ClusterDeleted(cluster, true)))
-        }
+        // Delete the cluster in Google and update the Operation in the database.
+        // Then shutdown this actor, but register a callback message to the supervisor
+        // telling it to recreate the cluster.
+        logger.info(s"Cluster ${cluster.googleProject}/${cluster.clusterName} is in an error state with code $code and message $message. Attempting to delete and recreate...")
+        for {
+          operation <- gdDAO.deleteCluster(cluster.googleProject, cluster.clusterName)
+          _ <- dbRef.inTransaction(_.clusterQuery.updateClusterOperation(cluster.googleId, operation.map(_.getName)))
+        } yield ShutdownActor(Some(ClusterDeleted(cluster, recreate = true)))
       } else {
+        logger.warn(s"Cluster ${cluster.googleProject}/${cluster.clusterName} is in an error state with code $code and message $message'. Unable to recreate cluster.")
         Future.successful(ShutdownActor())
       }
       future.attemptT
@@ -110,15 +145,25 @@ class ClusterMonitorActor(val cluster: Cluster,
   }
 
   private def shouldRecreateCluster(code: Int, message: Option[String]): Boolean = {
-    code == Code.UNKNOWN.value
+    monitorConfig.canRecreateCluster && (code == Code.UNKNOWN.value)
   }
 
+  /**
+    * Handles a dataproc cluster which has been deleted. We update the status to Deleted in the database,
+    * and shut down this actor.
+    * @return error or ShutdownActor
+    */
   private def handleDeletedCluster(): EitherT[Future, Throwable, ShutdownActor] = {
+    logger.info(s"Cluster ${cluster.googleProject}/${cluster.clusterName} has been deleted.")
     dbRef.inTransaction { dataAccess =>
       dataAccess.clusterQuery.updateClusterStatus(cluster.googleId, ClusterStatus.Deleted)
     }.map(_ => ShutdownActor()).attemptT
   }
 
+  /**
+    * Queries Google for a dataproc cluster and takes appropriate action depending on the status.
+    * @return error or ClusterMonitorMessage
+    */
   private def getGoogleCluster: EitherT[Future, Throwable, ClusterMonitorMessage] = {
     for {
       googleCluster <- gdDAO.getCluster(cluster.googleProject, cluster.clusterName).attemptT
@@ -132,6 +177,35 @@ class ClusterMonitorActor(val cluster: Cluster,
     } yield result
   }
 
+  /**
+    * Processes a running Google dataproc cluster, with error handling.
+    * @param cluster Google dataproc cluster
+    * @return error or ReadyCluster
+    */
+  private def processRunningCluster(cluster: GoogleCluster): EitherT[Future, Throwable, ReadyCluster] = {
+    for {
+      masterInstanceName <- getMasterInstanceName(cluster)
+      instance <- gdDAO.getInstance(cluster.getProjectId, masterInstanceName).attemptT
+      ip <- getInstanceIP(instance)
+    } yield ReadyCluster(ip)
+  }
+
+  /**
+    * Process a failed Google dataproc cluster, with error handling.
+    * @return error or FailedCluster
+    */
+  private def processFailedCluster(): EitherT[Future, Throwable, FailedCluster] = {
+    for {
+      op <- gdDAO.getOperation(cluster.operationName).attemptT
+      codeAndMessage <- getErrorCodeAndMessage(op)
+    } yield FailedCluster(codeAndMessage._1, codeAndMessage._2)
+  }
+
+  /**
+    * Gets the Leo ClusterStatus from a dataproc cluster, with error handling.
+    * @param cluster the Google dataproc cluster
+    * @return error or ClusterStatus
+    */
   private def getGoogleClusterStatus(cluster: GoogleCluster): EitherT[Future, Throwable, ClusterStatus] = {
     val errorOrGoogleStatus = for {
       status <- Option(cluster.getStatus)      .toRight(ClusterMonitorException("Cluster status is null"))
@@ -142,6 +216,11 @@ class ClusterMonitorActor(val cluster: Cluster,
     EitherT(Future.successful(errorOrGoogleStatus))
   }
 
+  /**
+    * Gets the master instance name from a dataproc cluster, with error handling.
+    * @param cluster the Google dataproc cluster
+    * @return error or master instance name
+    */
   private def getMasterInstanceName(cluster: GoogleCluster): EitherT[Future, Throwable, String] = {
     val errorOrMasterInstanceName = for {
       config <- Option(cluster.getConfig)                   .toRight(ClusterMonitorException("Cluster config is null"))
@@ -153,6 +232,11 @@ class ClusterMonitorActor(val cluster: Cluster,
     EitherT(Future.successful(errorOrMasterInstanceName))
   }
 
+  /**
+    * Gets the public IP from a google Instance, with error handling.
+    * @param instance the Google instance
+    * @return error or public IP, as a String
+    */
   private def getInstanceIP(instance: Instance): EitherT[Future, Throwable, String] = {
     val errorOrIp = for {
       interfaces <- Option(instance.getNetworkInterfaces).toRight(ClusterMonitorException("Network interfaces is null"))
@@ -164,29 +248,18 @@ class ClusterMonitorActor(val cluster: Cluster,
     EitherT(Future.successful(errorOrIp))
   }
 
-  private def processRunningCluster(cluster: GoogleCluster): EitherT[Future, Throwable, ReadyCluster] = {
-    for {
-      masterInstanceName <- getMasterInstanceName(cluster)
-      instance <- gdDAO.getInstance(cluster.getProjectId, masterInstanceName).attemptT
-      ip <- getInstanceIP(instance)
-    } yield ReadyCluster(ip)
-  }
-
-  private def getErrorCodeAndMessage(operation: Operation): EitherT[Future, Throwable, (Int, String)] = {
+  /**
+    * Gets the error code and message from a Google Operation, with error handling.
+    * @param operation the Operation to query
+    * @return error or (code, message)
+    */
+  private def getErrorCodeAndMessage(operation: Operation): EitherT[Future, Throwable, (Int, Option[String])] = {
     val errorOrCodeAndMessage = for {
       _ <- Option(operation.getDone).filter(_ == true).toRight(ClusterMonitorException("Operation is not done"))
       error <- Option(operation.getError).toRight(ClusterMonitorException("Operation error not found"))
       code <- Option(error.getCode)      .toRight(ClusterMonitorException("Operation code is null"))
-    } yield (code.toInt, error.getMessage)
+    } yield (code.toInt, Option(error.getMessage))
 
     EitherT(Future.successful(errorOrCodeAndMessage))
-  }
-
-
-  private def processFailedCluster(): EitherT[Future, Throwable, FailedCluster] = {
-    for {
-      op <- gdDAO.getOperation(cluster.operationName).attemptT
-      codeAndMessage <- getErrorCodeAndMessage(op)
-    } yield FailedCluster(codeAndMessage._1, Option(codeAndMessage._2))
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -1,0 +1,117 @@
+package org.broadinstitute.dsde.workbench.leonardo.monitor
+
+import akka.actor.{Actor, Props}
+import akka.pattern.pipe
+import cats._
+import cats.implicits._
+import cats.data._
+import com.google.api.services.compute.model.Instance
+import com.google.api.services.dataproc.model.{Cluster => GoogleCluster, Operation}
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.workbench.leonardo.dao.DataprocDAO
+import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
+import org.broadinstitute.dsde.workbench.leonardo.model.Cluster
+import org.broadinstitute.dsde.workbench.leonardo.model.ClusterStatus.Value
+import org.broadinstitute.dsde.workbench.leonardo.model.ModelTypes.GoogleProject
+import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorActor._
+
+import scala.concurrent.Future
+import scala.collection.JavaConverters._
+
+object ClusterMonitorActor {
+  def props(cluster: Cluster, gdDAO: DataprocDAO, dbRef: DbReference): Props =
+    Props(new ClusterMonitorActor(cluster, gdDAO, dbRef))
+
+  sealed trait ClusterMonitorMessage extends Product with Serializable
+  case object StartMonitorPass extends ClusterMonitorMessage
+  case class ReadyCluster(publicIP: String) extends ClusterMonitorMessage
+  case class NotReadyCluster(status: GoogleClusterStatusEnum.GoogleClusterStatus) extends ClusterMonitorMessage
+  case class FailedCluster(error: Option[GoogleClusterError]) extends ClusterMonitorMessage
+  case object ClusterDeleted extends ClusterMonitorMessage
+
+
+  private object GoogleClusterStatusEnum extends Enumeration {
+    type GoogleClusterStatus = Value
+    val Unknown, Creating, Running, Error, Deleted, Updating = Value
+
+    def fromStringIgnoreCase(str: String): Option[GoogleClusterStatus] = {
+      values.find(_.toString.equalsIgnoreCase(str))
+    }
+  }
+
+  private case class GoogleClusterError(code: Int, message: String)
+
+}
+
+class ClusterMonitorActor(val cluster: Cluster,
+                          val gdDAO: DataprocDAO,
+                          val dbRef: DbReference) extends Actor with LazyLogging {
+
+  import context.dispatcher
+  import GoogleClusterStatusEnum._
+
+  override def receive: Receive = {
+    case StartMonitorPass => getGoogleCluster pipeTo self
+  }
+
+  private def getGoogleCluster: Future[ClusterMonitorMessage] = {
+    gdDAO.getCluster(cluster.googleProject, cluster.clusterName).flatMap { c =>
+      val googleClusterStatus = getGoogleClusterStatus(c)
+      googleClusterStatus match {
+        case Unknown | Creating | Updating => Future.successful(NotReadyCluster(googleClusterStatus))
+        case Running => processRunningCluster(c)
+        case Error => processFailedCluster()
+        case Deleted => Future.successful(ClusterDeleted)
+      }
+    }
+  }
+
+  private def getGoogleClusterStatus(cluster: GoogleCluster): GoogleClusterStatus = {
+    val statusOpt = Option(cluster.getStatus).map(_.getState).flatMap(GoogleClusterStatusEnum.fromStringIgnoreCase)
+
+    statusOpt.getOrElse(throw new IllegalStateException(s"Unknown google status: ${cluster.getStatus}"))
+  }
+
+  private def getMasterInstanceName(cluster: GoogleCluster): String = {
+    val masterInstanceOpt = for {
+      config <- Option(cluster.getConfig)
+      masterConfig <- Option(config.getMasterConfig)
+      instanceNames <- Option(masterConfig.getInstanceNames)
+      masterInstance <- instanceNames.asScala.headOption
+    } yield masterInstance
+
+    masterInstanceOpt.getOrElse(throw new IllegalStateException(s"Could not get master node from cluster ${cluster.getClusterName}"))
+  }
+
+  private def getInstanceIP(instance: Instance): String = {
+    val ipOpt = for {
+      interfaces <- Option(instance.getNetworkInterfaces)
+      interface <- interfaces.asScala.headOption
+      accessConfigs <- Option(interface.getAccessConfigs)
+      accessConfig <- accessConfigs.asScala.headOption
+    } yield accessConfig.getNatIP
+
+    ipOpt.getOrElse(throw new IllegalStateException(s"Could not get IP from instance ${instance.getName}"))
+  }
+
+
+
+  private def processRunningCluster(cluster: GoogleCluster): Future[ReadyCluster] = {
+    gdDAO.getInstance(cluster.getProjectId, getMasterInstanceName(cluster)).map { instance =>
+      ReadyCluster(getInstanceIP(instance))
+    }
+  }
+
+  private def processFailedCluster(): Future[FailedCluster] = {
+    gdDAO.getOperation(cluster.operationName).map { op =>
+      val googleClusterErrorOpt = for {
+        done <- Option(op.getDone) if done == true
+        error <- Option(op.getError)
+      } yield GoogleClusterError(error.getCode, error.getMessage)
+
+      FailedCluster(googleClusterErrorOpt)
+    }
+  }
+
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -96,7 +96,7 @@ class ClusterMonitorActor(val cluster: Cluster,
     * @return error or ScheduleMonitorPass
     */
   private def handleNotReadyCluster(status: ClusterStatus): EitherT[Future, Throwable, ScheduleMonitorPass] = {
-    Future.successful(ScheduleMonitorPass()).attemptT
+    EitherT.pure(ScheduleMonitorPass())
   }
 
   /**
@@ -167,10 +167,10 @@ class ClusterMonitorActor(val cluster: Cluster,
       googleCluster <- gdDAO.getCluster(cluster.googleProject, cluster.clusterName).attemptT
       status <- getGoogleClusterStatus(googleCluster)
       result <- status match {
-        case Unknown | Creating | Updating => Future.successful(NotReadyCluster(status)).attemptT
+        case Unknown | Creating | Updating => EitherT.pure[Future, Throwable, ClusterMonitorMessage](NotReadyCluster(status))
         case Running => processRunningCluster(googleCluster)
         case Error => processFailedCluster()
-        case Deleted => Future.successful(DeletedCluster()).attemptT
+        case Deleted => EitherT.pure[Future, Throwable, ClusterMonitorMessage](DeletedCluster())
       }
     } yield result
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -62,7 +62,7 @@ class ClusterMonitorActor(val cluster: Cluster,
 
   override def receive: Receive = {
     case Right(msg) =>
-      logger.debug(s"Received message $msg")
+      logger.debug(s"ClusterMonitorActor: Received message $msg")
 
       msg match {
         case ScheduleMonitorPass() => scheduleMonitorPass
@@ -81,8 +81,7 @@ class ClusterMonitorActor(val cluster: Cluster,
       throw exception
 
     case Failure(exception) =>
-      // Shouldn't really happen as all Futures are lifted into EitherT.
-      // But take the same action anyway.
+      // An error occurred, let the supervisor handle & log it
       throw exception
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -2,123 +2,191 @@ package org.broadinstitute.dsde.workbench.leonardo.monitor
 
 import akka.actor.{Actor, Props}
 import akka.pattern.pipe
-import cats._
-import cats.implicits._
 import cats.data._
+import cats.implicits._
 import com.google.api.services.compute.model.Instance
-import com.google.api.services.dataproc.model.{Cluster => GoogleCluster, Operation}
+import com.google.api.services.dataproc.model.{Operation, Cluster => GoogleCluster}
 import com.typesafe.scalalogging.LazyLogging
+import io.grpc.Status.Code
 import org.broadinstitute.dsde.workbench.leonardo.dao.DataprocDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
-import org.broadinstitute.dsde.workbench.leonardo.model.Cluster
-import org.broadinstitute.dsde.workbench.leonardo.model.ClusterStatus.Value
-import org.broadinstitute.dsde.workbench.leonardo.model.ModelTypes.GoogleProject
+import org.broadinstitute.dsde.workbench.leonardo.model.ClusterStatus._
+import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, ClusterStatus, LeoException}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorActor._
+import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor.ClusterDeleted
 
-import scala.concurrent.Future
 import scala.collection.JavaConverters._
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Failure
 
 object ClusterMonitorActor {
   def props(cluster: Cluster, gdDAO: DataprocDAO, dbRef: DbReference): Props =
     Props(new ClusterMonitorActor(cluster, gdDAO, dbRef))
 
   sealed trait ClusterMonitorMessage extends Product with Serializable
-  case object StartMonitorPass extends ClusterMonitorMessage
+  case class ScheduleMonitorPass() extends ClusterMonitorMessage
+  case class StartMonitorPass() extends ClusterMonitorMessage
   case class ReadyCluster(publicIP: String) extends ClusterMonitorMessage
-  case class NotReadyCluster(status: GoogleClusterStatusEnum.GoogleClusterStatus) extends ClusterMonitorMessage
-  case class FailedCluster(error: Option[GoogleClusterError]) extends ClusterMonitorMessage
-  case object ClusterDeleted extends ClusterMonitorMessage
+  case class NotReadyCluster(status: ClusterStatus) extends ClusterMonitorMessage
+  case class FailedCluster(code: Int, message: Option[String]) extends ClusterMonitorMessage
+  case class DeletedCluster() extends ClusterMonitorMessage
+  case class ShutdownActor(notifyParentMsg: Option[Any] = None) extends ClusterMonitorMessage
 
-
-  private object GoogleClusterStatusEnum extends Enumeration {
-    type GoogleClusterStatus = Value
-    val Unknown, Creating, Running, Error, Deleted, Updating = Value
-
-    def fromStringIgnoreCase(str: String): Option[GoogleClusterStatus] = {
-      values.find(_.toString.equalsIgnoreCase(str))
-    }
-  }
-
-  private case class GoogleClusterError(code: Int, message: String)
+  private[monitor] case class ClusterMonitorException(errMsg: String) extends LeoException(errMsg)
 
 }
 
 class ClusterMonitorActor(val cluster: Cluster,
                           val gdDAO: DataprocDAO,
                           val dbRef: DbReference) extends Actor with LazyLogging {
+  import context._
 
-  import context.dispatcher
-  import GoogleClusterStatusEnum._
-
-  override def receive: Receive = {
-    case StartMonitorPass => getGoogleCluster pipeTo self
+  override def preStart(): Unit = {
+    scheduleMonitorPass
+    super.preStart()
   }
 
-  private def getGoogleCluster: EitherT[Future, String, ClusterMonitorMessage] = {
+  override def receive: Receive = {
+    case Right(ScheduleMonitorPass) =>
+      scheduleMonitorPass
+
+    case Right(StartMonitorPass) =>
+      getGoogleCluster.value pipeTo self
+
+    case Right(NotReadyCluster(status)) =>
+      handleNotReadyCluster(status).value pipeTo self
+
+    case Right(ReadyCluster(ip)) =>
+      handleReadyCluster(ip).value pipeTo self
+
+    case Right(FailedCluster(code, message)) =>
+      handleFailedCluster(code, message).value pipeTo self
+
+    case Right(DeletedCluster) =>
+      handleDeletedCluster().value pipeTo self
+
+    case Right(ShutdownActor(notifyParentMsg)) =>
+      notifyParentMsg.foreach(msg => parent ! msg)
+      stop(self)
+
+    case Left(exception: Throwable) =>
+      logger.error("Error occurred in ClusterMonitorActor", exception)
+      throw exception
+
+    case Failure(exception) =>
+      logger.error("Error occurred in ClusterMonitorActor", exception)
+      throw exception
+  }
+
+  def scheduleMonitorPass: Unit = {
+    context.system.scheduler.scheduleOnce(1 minute, self, Right(StartMonitorPass))
+  }
+
+  private def handleNotReadyCluster(status: ClusterStatus): EitherT[Future, Throwable, ScheduleMonitorPass] = {
+    for {
+      _ <- dbRef.inTransaction(_.clusterQuery.updateClusterStatus(cluster.googleId, status)).attemptT
+    } yield ScheduleMonitorPass()
+  }
+
+  private def handleReadyCluster(publicIp: String): EitherT[Future, Throwable, ShutdownActor] = {
+    dbRef.inTransaction { dataAccess =>
+      dataAccess.clusterQuery.updateClusterStatus(cluster.googleId, ClusterStatus.Running) andThen
+        dataAccess.clusterQuery.updateIpByGoogleId(cluster.googleId, publicIp)
+    }.map(_ => ShutdownActor()).attemptT
+  }
+
+  private def handleFailedCluster(code: Int, message: Option[String]): EitherT[Future, Throwable, ShutdownActor] = {
+    dbRef.inTransaction(_.clusterQuery.updateClusterStatus(cluster.googleId, ClusterStatus.Error)).attemptT.flatMap { _ =>
+      val future = if (shouldRecreateCluster(code, message)) {
+        gdDAO.deleteCluster(cluster.googleProject, cluster.clusterName).map { _ =>
+          ShutdownActor(Some(ClusterDeleted(cluster, true)))
+        }
+      } else {
+        Future.successful(ShutdownActor())
+      }
+      future.attemptT
+    }
+  }
+
+  private def shouldRecreateCluster(code: Int, message: Option[String]): Boolean = {
+    code == Code.UNKNOWN.value
+  }
+
+  private def handleDeletedCluster(): EitherT[Future, Throwable, ShutdownActor] = {
+    dbRef.inTransaction { dataAccess =>
+      dataAccess.clusterQuery.updateClusterStatus(cluster.googleId, ClusterStatus.Deleted)
+    }.map(_ => ShutdownActor()).attemptT
+  }
+
+  private def getGoogleCluster: EitherT[Future, Throwable, ClusterMonitorMessage] = {
     for {
       googleCluster <- gdDAO.getCluster(cluster.googleProject, cluster.clusterName).attemptT
       status <- getGoogleClusterStatus(googleCluster)
       result <- status match {
-        case Unknown | Creating | Updating => EitherT.right(Future.successful(NotReadyCluster(status)))
+        case Unknown | Creating | Updating => Future.successful(NotReadyCluster(status)).attemptT
         case Running => processRunningCluster(googleCluster)
         case Error => processFailedCluster()
-        case Deleted => EitherT.right(Future.successful(ClusterDeleted))
+        case Deleted => Future.successful(DeletedCluster()).attemptT
       }
     } yield result
   }
 
-  private def getGoogleClusterStatus(cluster: GoogleCluster): EitherT[Future, String, GoogleClusterStatus] = {
+  private def getGoogleClusterStatus(cluster: GoogleCluster): EitherT[Future, Throwable, ClusterStatus] = {
     val errorOrGoogleStatus = for {
-      status <- Option(cluster.getStatus).toRight("Cluster status is null")
-      state <- Option(status.getState).toRight("Cluster state is null")
-      googleStatus <- GoogleClusterStatusEnum.fromStringIgnoreCase(state).toRight(s"Unknown Google cluster status: $state")
+      status <- Option(cluster.getStatus)      .toRight(ClusterMonitorException("Cluster status is null"))
+      state <-  Option(status.getState)        .toRight(ClusterMonitorException("Cluster state is null"))
+      googleStatus <- withNameIgnoreCase(state).toRight(ClusterMonitorException(s"Unknown Google cluster status: $state"))
     } yield googleStatus
 
     EitherT(Future.successful(errorOrGoogleStatus))
   }
 
-  private def getMasterInstanceName(cluster: GoogleCluster): EitherT[Future, String, String] = {
+  private def getMasterInstanceName(cluster: GoogleCluster): EitherT[Future, Throwable, String] = {
     val errorOrMasterInstanceName = for {
-      config <- Option(cluster.getConfig).toRight("Cluster config is null")
-      masterConfig <- Option(config.getMasterConfig).toRight("Cluster master config is null")
-      instanceNames <- Option(masterConfig.getInstanceNames).toRight("Master config instance names is null")
-      masterInstance <- instanceNames.asScala.headOption.toRight("Master instance not found")
+      config <- Option(cluster.getConfig)                   .toRight(ClusterMonitorException("Cluster config is null"))
+      masterConfig <- Option(config.getMasterConfig)        .toRight(ClusterMonitorException("Cluster master config is null"))
+      instanceNames <- Option(masterConfig.getInstanceNames).toRight(ClusterMonitorException("Master config instance names is null"))
+      masterInstance <- instanceNames.asScala.headOption    .toRight(ClusterMonitorException("Master instance not found"))
     } yield masterInstance
 
     EitherT(Future.successful(errorOrMasterInstanceName))
   }
 
-  private def getInstanceIP(instance: Instance): EitherT[Future, String, String] = {
+  private def getInstanceIP(instance: Instance): EitherT[Future, Throwable, String] = {
     val errorOrIp = for {
-      interfaces <- Option(instance.getNetworkInterfaces).toRight("Network interfaces is null")
-      interface <- interfaces.asScala.headOption.toRight("Network interface not found")
-      accessConfigs <- Option(interface.getAccessConfigs).toRight("Access configs is null")
-      accessConfig <- accessConfigs.asScala.headOption.toRight("Access config not found")
+      interfaces <- Option(instance.getNetworkInterfaces).toRight(ClusterMonitorException("Network interfaces is null"))
+      interface <- interfaces.asScala.headOption         .toRight(ClusterMonitorException("Network interface not found"))
+      accessConfigs <- Option(interface.getAccessConfigs).toRight(ClusterMonitorException("Access configs is null"))
+      accessConfig <- accessConfigs.asScala.headOption   .toRight(ClusterMonitorException("Access config not found"))
     } yield accessConfig.getNatIP
 
     EitherT(Future.successful(errorOrIp))
   }
 
-
-
-  private def processRunningCluster(cluster: GoogleCluster): EitherT[Future, String, ReadyCluster] = {
+  private def processRunningCluster(cluster: GoogleCluster): EitherT[Future, Throwable, ReadyCluster] = {
     for {
       masterInstanceName <- getMasterInstanceName(cluster)
-      instance <- EitherT.right(gdDAO.getInstance(cluster.getProjectId, masterInstanceName))
+      instance <- gdDAO.getInstance(cluster.getProjectId, masterInstanceName).attemptT
       ip <- getInstanceIP(instance)
     } yield ReadyCluster(ip)
   }
 
-  private def processFailedCluster(): EitherT[Future, String, FailedCluster] = {
-    EitherT.right(gdDAO.getOperation(cluster.operationName).map { op =>
-      val googleClusterErrorOpt = for {
-        done <- Option(op.getDone) if done == true
-        error <- Option(op.getError)
-      } yield GoogleClusterError(error.getCode, error.getMessage)
+  private def getErrorCodeAndMessage(operation: Operation): EitherT[Future, Throwable, (Int, String)] = {
+    val errorOrCodeAndMessage = for {
+      _ <- Option(operation.getDone).filter(_ == true).toRight(ClusterMonitorException("Operation is not done"))
+      error <- Option(operation.getError).toRight(ClusterMonitorException("Operation error not found"))
+      code <- Option(error.getCode)      .toRight(ClusterMonitorException("Operation code is null"))
+    } yield (code.toInt, error.getMessage)
 
-      FailedCluster(googleClusterErrorOpt)
-    })
+    EitherT(Future.successful(errorOrCodeAndMessage))
   }
 
 
+  private def processFailedCluster(): EitherT[Future, Throwable, FailedCluster] = {
+    for {
+      op <- gdDAO.getOperation(cluster.operationName).attemptT
+      codeAndMessage <- getErrorCodeAndMessage(op)
+    } yield FailedCluster(codeAndMessage._1, Option(codeAndMessage._2))
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorActor.scala
@@ -219,7 +219,7 @@ class ClusterMonitorActor(val cluster: Cluster,
       googleStatus <- withNameIgnoreCase(state).toRight(ClusterMonitorException(s"Unknown Google cluster status: $state"))
     } yield googleStatus
 
-    EitherT(Future.successful(errorOrGoogleStatus))
+    EitherT.fromEither[Future](errorOrGoogleStatus)
   }
 
   /**
@@ -235,7 +235,7 @@ class ClusterMonitorActor(val cluster: Cluster,
       masterInstance <- instanceNames.asScala.headOption    .toRight(ClusterMonitorException("Master instance not found"))
     } yield masterInstance
 
-    EitherT(Future.successful(errorOrMasterInstanceName))
+    EitherT.fromEither[Future](errorOrMasterInstanceName)
   }
 
   /**
@@ -257,7 +257,7 @@ class ClusterMonitorActor(val cluster: Cluster,
       zoneUri <- Option(gceConfig.getZoneUri)           .toRight(ClusterMonitorException("Cluster zone is null"))
     } yield parseZone(zoneUri)
 
-    EitherT(Future.successful(errorOrMasterInstanceZone))
+    EitherT.fromEither[Future](errorOrMasterInstanceZone)
   }
 
   /**
@@ -273,7 +273,7 @@ class ClusterMonitorActor(val cluster: Cluster,
       accessConfig <- accessConfigs.asScala.headOption   .toRight(ClusterMonitorException("Access config not found"))
     } yield accessConfig.getNatIP
 
-    EitherT(Future.successful(errorOrIp))
+    EitherT.fromEither[Future](errorOrIp)
   }
 
   /**
@@ -288,6 +288,6 @@ class ClusterMonitorActor(val cluster: Cluster,
       code <- Option(error.getCode)      .toRight(ClusterMonitorException("Operation code is null"))
     } yield (code.toInt, Option(error.getMessage))
 
-    EitherT(Future.successful(errorOrCodeAndMessage))
+    EitherT.fromEither[Future](errorOrCodeAndMessage)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -1,0 +1,59 @@
+package org.broadinstitute.dsde.workbench.leonardo.monitor
+
+import akka.actor.SupervisorStrategy.Restart
+import akka.actor.{Actor, OneForOneStrategy, Props}
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.workbench.leonardo.dao.DataprocDAO
+import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
+import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, ClusterRequest}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor._
+
+import scala.util.{Failure, Success}
+
+object ClusterMonitorSupervisor {
+  def props(gdDAO: DataprocDAO, dbRef: DbReference): Props =
+    Props(new ClusterMonitorSupervisor(gdDAO, dbRef))
+
+  sealed trait ClusterSupervisorMessage
+  case class ClusterCreated(cluster: Cluster) extends ClusterSupervisorMessage
+  case class ClusterDeleted(cluster: Cluster, recreate: Boolean = false) extends ClusterSupervisorMessage
+  case class RecreateCluster(cluster: Cluster) extends ClusterSupervisorMessage
+}
+
+class ClusterMonitorSupervisor(gdDAO: DataprocDAO, dbRef: DbReference) extends Actor with LazyLogging {
+  import context.dispatcher
+
+  override def receive: Receive = {
+    case ClusterCreated(cluster) =>
+      startClusterMonitorActor(cluster)
+
+    case ClusterDeleted(cluster, recreate) =>
+      startClusterMonitorActor(cluster, recreate)
+
+    case RecreateCluster(cluster) =>
+      val clusterRequest = ClusterRequest(cluster.googleBucket, cluster.googleServiceAccount, cluster.labels)
+      gdDAO.createCluster(cluster.googleProject, cluster.clusterName, clusterRequest).map { clusterResponse =>
+        ClusterCreated(Cluster(clusterRequest, clusterResponse))
+      }.onComplete {
+        case Success(c) => self ! c
+        case Failure(e) =>
+          logger.error(s"Error recreating cluster ${cluster.googleProject}/${cluster.clusterName}", e)
+      }
+  }
+
+  def startClusterMonitorActor(cluster: Cluster, recreate: Boolean = false): Unit = {
+    val child = context.actorOf(ClusterMonitorActor.props(cluster, gdDAO, dbRef))
+
+    if (recreate) {
+      context.watchWith(child, RecreateCluster(cluster))
+    }
+  }
+
+  override val supervisorStrategy = {
+    // TODO add threshold monitoring stuff
+    // for now always restart
+    OneForOneStrategy() {
+      case _ => Restart
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -27,11 +27,11 @@ class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, gdDAO: DataprocDAO,
 
   override def receive: Receive = {
     case ClusterCreated(cluster) =>
-      logger.info(s"Monitoring cluster ${cluster.googleProject}/${cluster.clusterName}")
+      logger.info(s"Monitoring cluster ${cluster.googleProject}/${cluster.clusterName} for initialization")
       startClusterMonitorActor(cluster)
 
     case ClusterDeleted(cluster, recreate) =>
-      logger.info(s"Monitoring cluster ${cluster.googleProject}/${cluster.clusterName}")
+      logger.info(s"Monitoring cluster ${cluster.googleProject}/${cluster.clusterName} for deletion")
       startClusterMonitorActor(cluster, recreate)
 
     case RecreateCluster(cluster) =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -1,18 +1,20 @@
 package org.broadinstitute.dsde.workbench.leonardo.monitor
 
 import akka.actor.SupervisorStrategy.Restart
-import akka.actor.{Actor, OneForOneStrategy, Props}
+import akka.actor.{Actor, ActorRef, OneForOneStrategy, Props}
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.workbench.leonardo.config.MonitorConfig
 import org.broadinstitute.dsde.workbench.leonardo.dao.DataprocDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
 import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, ClusterRequest}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor._
 
-import scala.util.{Failure, Success}
+import scala.concurrent.Future
+import scala.util.{Failure, Random, Success}
 
 object ClusterMonitorSupervisor {
-  def props(gdDAO: DataprocDAO, dbRef: DbReference): Props =
-    Props(new ClusterMonitorSupervisor(gdDAO, dbRef))
+  def props(monitorConfig: MonitorConfig, gdDAO: DataprocDAO, dbRef: DbReference): Props =
+    Props(new ClusterMonitorSupervisor(monitorConfig, gdDAO, dbRef))
 
   sealed trait ClusterSupervisorMessage
   case class ClusterCreated(cluster: Cluster) extends ClusterSupervisorMessage
@@ -20,7 +22,7 @@ object ClusterMonitorSupervisor {
   case class RecreateCluster(cluster: Cluster) extends ClusterSupervisorMessage
 }
 
-class ClusterMonitorSupervisor(gdDAO: DataprocDAO, dbRef: DbReference) extends Actor with LazyLogging {
+class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, gdDAO: DataprocDAO, dbRef: DbReference) extends Actor with LazyLogging {
   import context.dispatcher
 
   override def receive: Receive = {
@@ -31,20 +33,38 @@ class ClusterMonitorSupervisor(gdDAO: DataprocDAO, dbRef: DbReference) extends A
       startClusterMonitorActor(cluster, recreate)
 
     case RecreateCluster(cluster) =>
-      val clusterRequest = ClusterRequest(cluster.googleBucket, cluster.googleServiceAccount, cluster.labels)
-      gdDAO.createCluster(cluster.googleProject, cluster.clusterName, clusterRequest).map { clusterResponse =>
-        ClusterCreated(Cluster(clusterRequest, clusterResponse))
-      }.onComplete {
-        case Success(c) => self ! c
-        case Failure(e) =>
-          logger.error(s"Error recreating cluster ${cluster.googleProject}/${cluster.clusterName}", e)
+      if (monitorConfig.canRecreateCluster) {
+        logger.info(s"Recreating cluster ${cluster.googleProject}/${cluster.clusterName}...")
+        val clusterRequest = ClusterRequest(cluster.googleBucket, cluster.googleServiceAccount, cluster.labels)
+        val clusterCreatedFuture = for {
+          clusterResponse <- gdDAO.createCluster(cluster.googleProject, cluster.clusterName, clusterRequest)
+          newCluster <- Future.successful(Cluster(clusterRequest, clusterResponse))
+          _ <- dbRef.inTransaction { dataAccess =>
+            // Append a random suffix to the old cluster name to prevent unique key conflicts in the database.
+            // This is a bit ugly; a better solution would be to have a unique yet on (googleId, clusterName, deletedAt)
+            dataAccess.clusterQuery.updateClusterName(cluster.googleId, appendRandomSuffix(cluster.clusterName)) andThen
+              dataAccess.clusterQuery.save(newCluster)
+          }
+        } yield ClusterCreated(newCluster)
+
+        clusterCreatedFuture.onComplete {
+          case Success(c) => self ! c
+          case Failure(e) =>
+            logger.error(s"Error recreating cluster ${cluster.googleProject}/${cluster.clusterName}", e)
+        }
+      } else {
+        logger.warn(s"Received RecreateCluster message for cluster ${cluster} but cluster recreation is disabled.")
       }
   }
 
-  def startClusterMonitorActor(cluster: Cluster, recreate: Boolean = false): Unit = {
-    val child = context.actorOf(ClusterMonitorActor.props(cluster, gdDAO, dbRef))
+  def createChildActor(cluster: Cluster): ActorRef = {
+    context.actorOf(ClusterMonitorActor.props(cluster, monitorConfig, gdDAO, dbRef))
+  }
 
-    if (recreate) {
+  def startClusterMonitorActor(cluster: Cluster, recreate: Boolean = false): Unit = {
+    val child = createChildActor(cluster)
+
+    if (recreate && monitorConfig.canRecreateCluster) {
       context.watchWith(child, RecreateCluster(cluster))
     }
   }
@@ -52,8 +72,12 @@ class ClusterMonitorSupervisor(gdDAO: DataprocDAO, dbRef: DbReference) extends A
   override val supervisorStrategy = {
     // TODO add threshold monitoring stuff
     // for now always restart
-    OneForOneStrategy() {
+    OneForOneStrategy(maxNrOfRetries = monitorConfig.maxRetries) {
       case _ => Restart
     }
+  }
+
+  private def appendRandomSuffix(str: String): String = {
+    s"${str}_${Random.alphanumeric.take(6).mkString}"
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -27,9 +27,11 @@ class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, gdDAO: DataprocDAO,
 
   override def receive: Receive = {
     case ClusterCreated(cluster) =>
+      logger.info(s"Monitoring cluster ${cluster.googleProject}/${cluster.clusterName}")
       startClusterMonitorActor(cluster)
 
     case ClusterDeleted(cluster, recreate) =>
+      logger.info(s"Monitoring cluster ${cluster.googleProject}/${cluster.clusterName}")
       startClusterMonitorActor(cluster, recreate)
 
     case RecreateCluster(cluster) =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -10,7 +10,7 @@ import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, ClusterRequest
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor._
 
 import scala.concurrent.Future
-import scala.util.{Failure, Random, Success}
+import scala.util.{Failure, Success}
 
 object ClusterMonitorSupervisor {
   def props(monitorConfig: MonitorConfig, gdDAO: DataprocDAO, dbRef: DbReference): Props =
@@ -72,9 +72,5 @@ class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, gdDAO: DataprocDAO,
     OneForOneStrategy(maxNrOfRetries = monitorConfig.maxRetries) {
       case _ => Restart
     }
-  }
-
-  private def appendRandomSuffix(str: String): String = {
-    s"${str}_${Random.alphanumeric.take(6).mkString}"
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -67,8 +67,8 @@ class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, gdDAO: DataprocDAO,
   }
 
   override val supervisorStrategy = {
-    // TODO add threshold monitoring stuff
-    // for now always restart
+    // TODO add threshold monitoring stuff from Rawls
+    // for now always restart the child actor in case of failure
     OneForOneStrategy(maxNrOfRetries = monitorConfig.maxRetries) {
       case _ => Restart
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -1,18 +1,22 @@
 package org.broadinstitute.dsde.workbench.leonardo.service
 
+import akka.actor.ActorRef
 import akka.http.scaladsl.model.StatusCodes
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.leonardo.dao.DataprocDAO
 import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, ClusterRequest, ClusterResponse, ClusterStatus, LeoException}
 import org.broadinstitute.dsde.workbench.leonardo.db.{DataAccess, DbReference}
 import org.broadinstitute.dsde.workbench.leonardo.model.ModelTypes.GoogleProject
+import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor
+import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor.{ClusterCreated, ClusterDeleted}
 import slick.dbio.DBIO
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Success
 
 case class ClusterNotFoundException(googleProject: GoogleProject, clusterName: String) extends LeoException(s"Cluster $googleProject/$clusterName not found", StatusCodes.NotFound)
 
-class LeonardoService(gdDAO: DataprocDAO, dbRef: DbReference)(implicit val executionContext: ExecutionContext) extends LazyLogging {
+class LeonardoService(gdDAO: DataprocDAO, dbRef: DbReference, val clusterMonitorSupervisor: ActorRef)(implicit val executionContext: ExecutionContext) extends LazyLogging {
 
   protected def getCluster(googleProject: GoogleProject, clusterName: String, dataAccess: DataAccess): DBIO[Cluster] = {
     dataAccess.clusterQuery.getByName(googleProject, clusterName) flatMap {
@@ -26,6 +30,8 @@ class LeonardoService(gdDAO: DataprocDAO, dbRef: DbReference)(implicit val execu
       dbRef.inTransaction { dataAccess =>
         dataAccess.clusterQuery.save(Cluster(clusterRequest, clusterResponse))
       }
+    } andThen { case Success(cluster) =>
+      clusterMonitorSupervisor ! ClusterCreated(cluster)
     }
   }
 
@@ -38,10 +44,13 @@ class LeonardoService(gdDAO: DataprocDAO, dbRef: DbReference)(implicit val execu
   def deleteCluster(googleProject: GoogleProject, clusterName: String): Future[Int] = {
     getClusterDetails(googleProject, clusterName) flatMap  { cluster =>
       if(cluster.status.isActive) {
-        for {
+        val deletFuture = for {
           _ <- gdDAO.deleteCluster(googleProject, clusterName)
           recordCount <- dbRef.inTransaction(dataAccess => dataAccess.clusterQuery.deleteCluster(cluster.googleId))
         } yield recordCount
+        deletFuture andThen { case Success(_) =>
+          clusterMonitorSupervisor ! ClusterDeleted(cluster)
+        }
       } else Future.successful(0)
     }
   }

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -31,7 +31,7 @@ liquibase {
 dataproc {
   dataprocInitScriptURI = ""
   dataprocDockerImage = ""
-  dataprocDefaultZone = ""
+  dataprocDefaultRegion = ""
   serviceAccount = ""
   pathToLeonardoPem = ""
   clusterUrlBase = ""

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
   */
 trait TestLeoRoutes { this: ScalatestRouteTest =>
   val mockGoogleDataprocDAO = new MockGoogleDataprocDAO
-  val leonardoService = new LeonardoService(mockGoogleDataprocDAO, DbSingleton.ref)
+  val leonardoService = new LeonardoService(mockGoogleDataprocDAO, DbSingleton.ref, system.deadLetters)
   val proxyConfig = ProxyConfig(jupyterPort = 8001, jupyterDomain = "", dnsPollPeriod = 1 day)
   val proxyService = new MockProxyService(proxyConfig, DbSingleton.ref)
   val swaggerConfig = SwaggerConfig("", "")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockGoogleDataprocDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockGoogleDataprocDAO.scala
@@ -2,6 +2,9 @@ package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import java.util.UUID
 
+import com.google.api.services.compute.model.Instance
+import com.google.api.services.dataproc.model.{Cluster => GoogleCluster, _}
+import org.broadinstitute.dsde.workbench.leonardo.model.ModelTypes.GoogleProject
 import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, ClusterRequest, ClusterResponse}
 
 import scala.collection.concurrent.TrieMap
@@ -22,9 +25,15 @@ class MockGoogleDataprocDAO extends DataprocDAO {
     Future.successful(clusterResponse)
   }
 
-  override def deleteCluster(googleProject: String, clusterName: String)(implicit executionContext: ExecutionContext): Future[Unit] = {
+  override def deleteCluster(googleProject: String, clusterName: String)(implicit executionContext: ExecutionContext): Future[Option[Operation]] = {
     if(clusters.contains(clusterName))
       clusters.remove(clusterName)
-    Future(())
+    Future(None)
   }
+
+  override def getCluster(googleProject: GoogleProject, clusterName: String)(implicit executionContext: ExecutionContext): Future[GoogleCluster] = ???
+
+  override def getOperation(operationName: String)(implicit executionContext: ExecutionContext): Future[Operation] = ???
+
+  override def getInstance(googleProject: GoogleProject, instanceName: String)(implicit executionContext: ExecutionContext): Future[Instance] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockGoogleDataprocDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockGoogleDataprocDAO.scala
@@ -35,5 +35,5 @@ class MockGoogleDataprocDAO extends DataprocDAO {
 
   override def getOperation(operationName: String)(implicit executionContext: ExecutionContext): Future[Operation] = ???
 
-  override def getInstance(googleProject: GoogleProject, instanceName: String)(implicit executionContext: ExecutionContext): Future[Instance] = ???
+  override def getInstance(googleProject: GoogleProject, zone: String, instanceName: String)(implicit executionContext: ExecutionContext): Future[Instance] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -82,13 +82,13 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike {
       labels = Map.empty)
     dbFailure { _.clusterQuery.save(c4) } shouldBe a[SQLException]
 
-    dbFutureValue { _.clusterQuery.deleteCluster(c1.googleId) } shouldEqual 1
+    dbFutureValue { _.clusterQuery.deleteCluster(c1.googleId, None) } shouldEqual 1
     dbFutureValue { _.clusterQuery.listActive() } shouldEqual Seq(c2)
     val c1status = dbFutureValue { _.clusterQuery.getByGoogleId(c1.googleId) }.get
     c1status.status shouldEqual ClusterStatus.Deleting
     assert(c1status.destroyedDate.nonEmpty)
 
-    dbFutureValue { _.clusterQuery.deleteCluster(c2.googleId) } shouldEqual 1
+    dbFutureValue { _.clusterQuery.deleteCluster(c2.googleId, None) } shouldEqual 1
     dbFutureValue { _.clusterQuery.listActive() } shouldEqual Seq()
     val c2status = dbFutureValue { _.clusterQuery.getByGoogleId(c2.googleId) }.get
     c2status.status shouldEqual ClusterStatus.Deleting

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -13,7 +13,7 @@ import org.broadinstitute.dsde.workbench.leonardo.dao.DataprocDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.{DbReference, DbSingleton, TestComponent}
 import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, ClusterRequest, ClusterResponse, ClusterStatus}
 import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor.{ClusterCreated, ClusterDeleted}
-import org.mockito.ArgumentMatchers.{any, eq => eqq}
+import org.mockito.ArgumentMatchers.{eq => eqq, _}
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
@@ -89,10 +89,12 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
       dao.getCluster(eqq(creatingCluster.googleProject), eqq(creatingCluster.clusterName))(any[ExecutionContext])
     } thenReturn Future.successful {
       new GoogleCluster().setStatus(new GoogleClusterStatus().setState("RUNNING")).setProjectId(creatingCluster.googleProject)
-        .setConfig(new ClusterConfig().setMasterConfig(new InstanceGroupConfig().setInstanceNames(List("masterInstance").asJava)))
+        .setConfig(new ClusterConfig()
+          .setMasterConfig(new InstanceGroupConfig().setInstanceNames(List("masterInstance").asJava))
+          .setGceClusterConfig(new GceClusterConfig().setZoneUri("us-central1-c")))
     }
     when {
-      dao.getInstance(eqq(creatingCluster.googleProject), eqq("masterInstance"))(any[ExecutionContext])
+      dao.getInstance(eqq(creatingCluster.googleProject), anyString, eqq("masterInstance"))(any[ExecutionContext])
     } thenReturn Future.successful {
       new Instance().setNetworkInterfaces(List(new NetworkInterface().setAccessConfigs(List(new AccessConfig().setNatIP("1.2.3.4")).asJava)).asJava)
     }
@@ -210,7 +212,8 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
       new GoogleCluster().setStatus(new GoogleClusterStatus().setState("CREATING"))
     } thenReturn Future.successful {
       new GoogleCluster().setStatus(new GoogleClusterStatus().setState("RUNNING")).setProjectId(creatingCluster.googleProject)
-        .setConfig(new ClusterConfig().setMasterConfig(new InstanceGroupConfig().setInstanceNames(List("masterInstance").asJava)))
+        .setConfig(new ClusterConfig().setMasterConfig(new InstanceGroupConfig().setInstanceNames(List("masterInstance").asJava))
+        .setGceClusterConfig(new GceClusterConfig().setZoneUri("us-central1-c")))
     }
 
     when {
@@ -231,7 +234,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     }
 
     when {
-      dao.getInstance(eqq(creatingCluster.googleProject), eqq("masterInstance"))(any[ExecutionContext])
+      dao.getInstance(eqq(creatingCluster.googleProject), anyString, eqq("masterInstance"))(any[ExecutionContext])
     } thenReturn Future.successful {
       new Instance().setNetworkInterfaces(List(new NetworkInterface().setAccessConfigs(List(new AccessConfig().setNatIP("1.2.3.4")).asJava)).asJava)
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -1,0 +1,261 @@
+package org.broadinstitute.dsde.workbench.leonardo.monitor
+
+import java.time.Instant
+import java.util.UUID
+
+import akka.actor.{ActorRef, ActorSystem, Props, Terminated}
+import akka.testkit.TestKit
+import com.google.api.services.compute.model.{AccessConfig, Instance, NetworkInterface}
+import com.google.api.services.dataproc.model.{Cluster => GoogleCluster, ClusterStatus => GoogleClusterStatus, _}
+import io.grpc.Status.Code
+import org.broadinstitute.dsde.workbench.leonardo.config.MonitorConfig
+import org.broadinstitute.dsde.workbench.leonardo.dao.DataprocDAO
+import org.broadinstitute.dsde.workbench.leonardo.db.{DbReference, DbSingleton, TestComponent}
+import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster, ClusterRequest, ClusterResponse, ClusterStatus}
+import org.broadinstitute.dsde.workbench.leonardo.monitor.ClusterMonitorSupervisor.{ClusterCreated, ClusterDeleted}
+import org.mockito.ArgumentMatchers.{any, eq => eqq}
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Created by rtitle on 9/6/17.
+  */
+class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatSpecLike with Matchers with MockitoSugar with BeforeAndAfterAll with TestComponent { testKit =>
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+
+  val creatingCluster = Cluster(
+    clusterName = "name1",
+    googleId = UUID.randomUUID(),
+    googleProject = "dsp-leo-test",
+    googleServiceAccount = "not-a-service-acct@google.com",
+    googleBucket = "bucket1",
+    clusterUrl = Cluster.getClusterUrl("dsp-leo-test", "name1"),
+    operationName = "op1",
+    status = ClusterStatus.Creating,
+    hostIp = None,
+    createdDate = Instant.now(),
+    destroyedDate = None,
+    labels = Map("bam" -> "yes", "vcf" -> "no"))
+
+  val deletingCluster = Cluster(
+    clusterName = "name2",
+    googleId = UUID.randomUUID(),
+    googleProject = "dsp-leo-test",
+    googleServiceAccount = "not-a-service-acct@google.com",
+    googleBucket = "bucket1",
+    clusterUrl = Cluster.getClusterUrl("dsp-leo-test", "name1"),
+    operationName = "op1",
+    status = ClusterStatus.Deleting,
+    hostIp = Some("numbers.and.dots"),
+    createdDate = Instant.now(),
+    destroyedDate = None,
+    labels = Map("bam" -> "yes", "vcf" -> "no"))
+
+  /**
+    * Extends ClusterMonitorSupervisor so the akka TestKit can watch the child ClusterMontitorActor's.
+    */
+  class TestSupervisor(gdDAO: DataprocDAO, dbRef: DbReference) extends ClusterMonitorSupervisor(MonitorConfig(1 second), gdDAO, dbRef) {
+    override def createChildActor(cluster: Cluster): ActorRef = {
+      val child = super.createChildActor(cluster)
+      testKit watch child
+      child
+    }
+  }
+
+  def createClusterSupervisor(dao: DataprocDAO): ActorRef = {
+    system.actorOf(Props(new TestSupervisor(dao, DbSingleton.ref)))
+  }
+
+  // Pre:
+  // - cluster exists in the DB with status Creating
+  // - dataproc DAO returns status RUNNING
+  // Post:
+  // - cluster is updated in the DB with status Running and the host IP
+  // - monitor actor shuts down
+  "ClusterMonitorActor" should "monitor until RUNNING state" in isolatedDbTest {
+    dbFutureValue { _.clusterQuery.save(creatingCluster) } shouldEqual creatingCluster
+
+    val dao = mock[DataprocDAO]
+    when {
+      dao.getCluster(eqq(creatingCluster.googleProject), eqq(creatingCluster.clusterName))(any[ExecutionContext])
+    } thenReturn Future.successful {
+      new GoogleCluster().setStatus(new GoogleClusterStatus().setState("RUNNING")).setProjectId(creatingCluster.googleProject)
+        .setConfig(new ClusterConfig().setMasterConfig(new InstanceGroupConfig().setInstanceNames(List("masterInstance").asJava)))
+    }
+    when {
+      dao.getInstance(eqq(creatingCluster.googleProject), eqq("masterInstance"))(any[ExecutionContext])
+    } thenReturn Future.successful {
+      new Instance().setNetworkInterfaces(List(new NetworkInterface().setAccessConfigs(List(new AccessConfig().setNatIP("1.2.3.4")).asJava)).asJava)
+    }
+
+    createClusterSupervisor(dao) ! ClusterCreated(creatingCluster)
+
+    expectMsgClass(5 seconds, classOf[Terminated])
+    val updatedCluster = dbFutureValue { _.clusterQuery.getByName(creatingCluster.googleProject, creatingCluster.clusterName) }
+    updatedCluster shouldBe 'defined
+    updatedCluster.map(_.status) shouldBe Some(ClusterStatus.Running)
+    updatedCluster.flatMap(_.hostIp) shouldBe Some("1.2.3.4")
+  }
+
+  // Pre:
+  // - cluster exists in the DB with status Creating
+  // - dataproc DAO returns status CREATING, UNKNOWN, or UPDATING
+  // Post:
+  // - cluster is not changed in the DB
+  // - monitor actor does not shut down
+  Seq("CREATING", "UNKNOWN", "UPDATING").map { state =>
+    it should s"monitor $state state" in isolatedDbTest {
+      dbFutureValue { _.clusterQuery.save(creatingCluster) } shouldEqual creatingCluster
+
+      val dao = mock[DataprocDAO]
+      when {
+        dao.getCluster(eqq(creatingCluster.googleProject), eqq(creatingCluster.clusterName))(any[ExecutionContext])
+      } thenReturn Future.successful {
+        new GoogleCluster().setStatus(new GoogleClusterStatus().setState(state))
+      }
+
+      createClusterSupervisor(dao) ! ClusterCreated(creatingCluster)
+
+      expectNoMsg(5 seconds)
+
+      val updatedCluster = dbFutureValue { _.clusterQuery.getByName(creatingCluster.googleProject, creatingCluster.clusterName) }
+      updatedCluster shouldBe 'defined
+      updatedCluster shouldBe Some(creatingCluster)
+    }
+  }
+
+  // Pre:
+  // - cluster exists in the DB with status Creating
+  // - dataproc DAO returns status ERROR and error code CANCELLED
+  // Post:
+  // - cluster status is set to Error in the DB
+  // - monitor actor shuts down
+  it should "monitor until ERROR state with no restart" in isolatedDbTest {
+    dbFutureValue { _.clusterQuery.save(creatingCluster) } shouldEqual creatingCluster
+
+    val dao = mock[DataprocDAO]
+    when {
+      dao.getCluster(eqq(creatingCluster.googleProject), eqq(creatingCluster.clusterName))(any[ExecutionContext])
+    } thenReturn Future.successful {
+      new GoogleCluster().setStatus(new GoogleClusterStatus().setState("ERROR"))
+    }
+    when {
+      dao.getOperation(eqq("op1"))(any[ExecutionContext])
+    } thenReturn Future.successful {
+      new Operation().setDone(true).setError(new Status().setCode(Code.CANCELLED.value()).setMessage("test message"))
+    }
+
+    createClusterSupervisor(dao) ! ClusterCreated(creatingCluster)
+
+    expectMsgClass(5 seconds, classOf[Terminated])
+    val updatedCluster = dbFutureValue { _.clusterQuery.getByName(creatingCluster.googleProject, creatingCluster.clusterName) }
+    updatedCluster shouldBe 'defined
+    updatedCluster.map(_.status) shouldBe Some(ClusterStatus.Error)
+    updatedCluster.flatMap(_.hostIp) shouldBe None
+  }
+
+  // Pre:
+  // - cluster exists in the DB with status Deleting
+  // - dataproc DAO returns status DELETED
+  // Post:
+  // - cluster status is set to Deleted in the DB
+  // - monitor actor shuts down
+  it should "monitor until DELETED state" in isolatedDbTest {
+    dbFutureValue { _.clusterQuery.save(deletingCluster) } shouldEqual deletingCluster
+
+    val dao = mock[DataprocDAO]
+    when {
+      dao.getCluster(eqq(deletingCluster.googleProject), eqq(deletingCluster.clusterName))(any[ExecutionContext])
+    } thenReturn Future.successful {
+      new GoogleCluster().setStatus(new GoogleClusterStatus().setState("DELETED"))
+    }
+
+    createClusterSupervisor(dao) ! ClusterDeleted(deletingCluster)
+
+    expectMsgClass(5 seconds, classOf[Terminated])
+    val updatedCluster = dbFutureValue { _.clusterQuery.getByName(deletingCluster.googleProject, deletingCluster.clusterName) }
+    updatedCluster shouldBe 'defined
+    updatedCluster.map(_.status) shouldBe Some(ClusterStatus.Deleted)
+    updatedCluster.flatMap(_.hostIp) shouldBe deletingCluster.hostIp
+  }
+
+  // Pre:
+  // - cluster exists in the DB with status Creating
+  // - dataproc DAO returns status ERROR and error code UNKNOWN
+  // Post:
+  // - old cluster status is set to Deleted in the DB
+  // - new cluster exists with the original cluster name
+  // - new cluster has status Running and the host IP
+  // - monitor actor shuts down
+  it should "monitor until ERROR state with restart" in isolatedDbTest {
+    dbFutureValue { _.clusterQuery.save(creatingCluster) } shouldEqual creatingCluster
+
+    val dao = mock[DataprocDAO]
+    when {
+      dao.getCluster(eqq(creatingCluster.googleProject), eqq(creatingCluster.clusterName))(any[ExecutionContext])
+    } thenReturn Future.successful {
+      new GoogleCluster().setStatus(new GoogleClusterStatus().setState("ERROR"))
+    } thenReturn Future.successful {
+      new GoogleCluster().setStatus(new GoogleClusterStatus().setState("DELETED"))
+    } thenReturn Future.successful {
+      new GoogleCluster().setStatus(new GoogleClusterStatus().setState("CREATING"))
+    } thenReturn Future.successful {
+      new GoogleCluster().setStatus(new GoogleClusterStatus().setState("RUNNING")).setProjectId(creatingCluster.googleProject)
+        .setConfig(new ClusterConfig().setMasterConfig(new InstanceGroupConfig().setInstanceNames(List("masterInstance").asJava)))
+    }
+
+    when {
+      dao.getOperation(eqq("op1"))(any[ExecutionContext])
+    } thenReturn Future.successful {
+      new Operation().setDone(true).setError(new Status().setCode(Code.UNKNOWN.value()).setMessage("test message"))
+    }
+
+    when {
+      dao.deleteCluster(eqq(creatingCluster.googleProject), eqq(creatingCluster.clusterName))(any[ExecutionContext])
+    } thenReturn Future.successful(Some(new Operation().setName("new op")))
+
+    val newClusterId = UUID.randomUUID()
+    when {
+      dao.createCluster(eqq(creatingCluster.googleProject), eqq(creatingCluster.clusterName), any[ClusterRequest])(any[ExecutionContext])
+    } thenReturn Future.successful {
+      ClusterResponse(creatingCluster.clusterName, creatingCluster.googleProject, newClusterId.toString, "CREATING", "description", "create op")
+    }
+
+    when {
+      dao.getInstance(eqq(creatingCluster.googleProject), eqq("masterInstance"))(any[ExecutionContext])
+    } thenReturn Future.successful {
+      new Instance().setNetworkInterfaces(List(new NetworkInterface().setAccessConfigs(List(new AccessConfig().setNatIP("1.2.3.4")).asJava)).asJava)
+    }
+
+    createClusterSupervisor(dao) ! ClusterCreated(creatingCluster)
+
+    // Expect 3 Terminated messages:
+    // 1. original cluster monitor, terminates at Error status
+    // 2. deletion monitor, terminates at Deleted status
+    // 3. new Cluster creating monitor, terminates at Running status
+    expectMsgClass(5 seconds, classOf[Terminated])
+    expectMsgClass(5 seconds, classOf[Terminated])
+    expectMsgClass(5 seconds, classOf[Terminated])
+
+    val oldCluster = dbFutureValue { _.clusterQuery.getByGoogleId(creatingCluster.googleId) }
+    oldCluster shouldBe 'defined
+    oldCluster.map(_.status) shouldBe Some(ClusterStatus.Deleted)
+    oldCluster.flatMap(_.hostIp) shouldBe None
+
+    val newCluster = dbFutureValue { _.clusterQuery.getByName(creatingCluster.googleProject, creatingCluster.clusterName) }
+    newCluster shouldBe 'defined
+    newCluster.map(_.googleId) shouldBe Some(newClusterId)
+    newCluster.map(_.status) shouldBe Some(ClusterStatus.Running)
+    newCluster.flatMap(_.hostIp) shouldBe Some("1.2.3.4")
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -184,7 +184,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     createClusterSupervisor(dao) ! ClusterDeleted(deletingCluster)
 
     expectMsgClass(5 seconds, classOf[Terminated])
-    val updatedCluster = dbFutureValue { _.clusterQuery.getByName(deletingCluster.googleProject, deletingCluster.clusterName) }
+    val updatedCluster = dbFutureValue { _.clusterQuery.getByGoogleId(deletingCluster.googleId) }
     updatedCluster shouldBe 'defined
     updatedCluster.map(_.status) shouldBe Some(ClusterStatus.Deleted)
     updatedCluster.flatMap(_.hostIp) shouldBe deletingCluster.hostIp

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -21,7 +21,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   val dataprocConfig = ConfigFactory.load().as[DataprocConfig]("dataproc")
 
   val gdDAO = new MockGoogleDataprocDAO
-  val leo = new LeonardoService(gdDAO, DbSingleton.ref)
+  val leo = new LeonardoService(gdDAO, DbSingleton.ref, system.deadLetters)
 
   "LeonardoService" should "create and get a cluster" in isolatedDbTest {
     val clusterRequest = ClusterRequest("bucketPath", "serviceAccount", Map[String, String]())
@@ -43,8 +43,8 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     val clusterRequest = ClusterRequest("bucketPath", "serviceAccount", Map[String, String]())
 
     val clusterCreateResponse = leo.createCluster("googleProject", "clusterName", clusterRequest).futureValue
-    val clusterGetResponse = leo.deleteCluster("googleProject", "clusterName").futureValue
-    clusterGetResponse shouldEqual 1
+    val clusterDeleteResponse = leo.deleteCluster("googleProject", "clusterName").futureValue
+    clusterDeleteResponse shouldEqual ()
   }
 
   "LeonardoService" should "throw ClusterNotFoundException when deleting non existent clusters" in isolatedDbTest {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -44,7 +44,6 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
 
     val clusterCreateResponse = leo.createCluster("googleProject", "clusterName", clusterRequest).futureValue
     val clusterDeleteResponse = leo.deleteCluster("googleProject", "clusterName").futureValue
-    clusterDeleteResponse shouldEqual ()
   }
 
   "LeonardoService" should "throw ClusterNotFoundException when deleting non existent clusters" in isolatedDbTest {


### PR DESCRIPTION
https://broadinstitute.atlassian.net/browse/GAWB-2498

Added a `ClusterMonitorActor/Supervisor` which is responsible for:
- monitoring newly created clusters until they reach Running state
- monitoring deleting clusters until they reach Deleted state
- reacting to errors during cluster initialization, and potentially recreating the cluster

I tested with a local Leo by creating and deleting clusters, and it works as expected. See inline for code-specific comments.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
