### PR TITLE
[GAWB-2535] Notebook Service: support user-defined notebook extensions

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -5,4 +5,5 @@
     <include file="changesets/cluster-unique-key.xml" relativeToChangelogFile="true"/>
     <include file="changesets/cluster-googleId-unique-key.xml" relativeToChangelogFile="true"/>
     <include file="changesets/cluster-createdDate-default.xml" relativeToChangelogFile="true" />
+    <include file="changesets/cluster-extensionUri-column.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -5,5 +5,5 @@
     <include file="changesets/cluster-unique-key.xml" relativeToChangelogFile="true"/>
     <include file="changesets/cluster-googleId-unique-key.xml" relativeToChangelogFile="true"/>
     <include file="changesets/cluster-createdDate-default.xml" relativeToChangelogFile="true" />
-    <include file="changesets/cluster-extensionUri-column.xml" relativeToChangelogFile="true" />
+    <include file="changesets/cluster-jupyterExtensionUri-column.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/cluster-extensionUri-column.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/cluster-extensionUri-column.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="leonardo" author="rtitle" id="cluster-extensionUri-column">
+        <addColumn tableName="CLUSTER">
+            <column name="extensionUri" type="varchar(254)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/cluster-jupyterExtensionUri-column.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/cluster-jupyterExtensionUri-column.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
-    <changeSet logicalFilePath="leonardo" author="rtitle" id="cluster-extensionUri-column">
+    <changeSet logicalFilePath="leonardo" author="rtitle" id="cluster-jupyterExtensionUri-column">
         <addColumn tableName="CLUSTER">
-            <column name="extensionUri" type="varchar(254)"/>
+            <column name="jupyterExtensionUri" type="varchar(254)"/>
         </addColumn>
     </changeSet>
 

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/cluster-jupyterExtensionUri-column.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/cluster-jupyterExtensionUri-column.xml
@@ -3,7 +3,7 @@
 
     <changeSet logicalFilePath="leonardo" author="rtitle" id="cluster-jupyterExtensionUri-column">
         <addColumn tableName="CLUSTER">
-            <column name="jupyterExtensionUri" type="varchar(254)"/>
+            <column name="jupyterExtensionUri" type="varchar(1024)"/>
         </addColumn>
     </changeSet>
 

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -286,13 +286,13 @@ definitions:
         description: The IP address of the cluster master node
       createdDate:
         type: string
-        description: 'The date and time the cluster was created, in ISO-8601 format'
+        description: The date and time the cluster was created, in ISO-8601 format
       destroyedDate:
         type: string
-        description: 'The date and time the cluster was destroyed, in ISO-8601 format'
+        description: The date and time the cluster was destroyed, in ISO-8601 format
       labels:
         type: object
-        description: 'The labels to be placed on the cluster. Of type Map[String,String]'
+        description: The labels to be placed on the cluster. Of type Map[String,String]
   ClusterRequest:
     description: ''
     required:
@@ -308,4 +308,11 @@ definitions:
         description: The service account of the user
       labels:
         type: object
-        description: 'The labels to be placed on the cluster. Of type Map[String,String]'
+        description: The labels to be placed on the cluster. Of type Map[String,String]
+      extensionUri:
+        type: string
+        description: |
+          Optional bucket URI to an archive containing Jupyter notebook extension files.
+          The archive must be in tar.gz format, must not include a parent directory, and
+          must have an entry point named 'main'.
+

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -309,7 +309,7 @@ definitions:
       labels:
         type: object
         description: The labels to be placed on the cluster. Of type Map[String,String]
-      extensionUri:
+      jupyterExtensionUri:
         type: string
         description: |
           Optional bucket URI to an archive containing Jupyter notebook extension files.

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -314,5 +314,6 @@ definitions:
         description: |
           Optional bucket URI to an archive containing Jupyter notebook extension files.
           The archive must be in tar.gz format, must not include a parent directory, and
-          must have an entry point named 'main'.
+          must have an entry point named 'main'. For more information on notebook extensions,
+          see: http://jupyter-notebook.readthedocs.io/en/latest/extending/frontend_extensions.html.
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/DataprocConfig.scala
@@ -20,4 +20,5 @@ case class DataprocConfig(applicationName: String,
                           jupyterProxySiteConfName: String,
                           clusterUrlBase: String,
                           jupyterServerName: String,
-                          proxyServerName: String)
+                          proxyServerName: String,
+                          jupyterInstallExtensionScript: String)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
@@ -34,7 +34,8 @@ package object config {
       config.getString("proxySiteConf"),
       config.getString("clusterUrlBase"),
       config.getString("jupyterServerName"),
-      config.getString("proxyServerName"))
+      config.getString("proxyServerName"),
+      config.getString("jupyterInstallExtensionScript"))
   }
 
   implicit val liquibaseReader: ValueReader[LiquibaseConfig] = ValueReader.relative { config =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DataprocDAO.scala
@@ -20,6 +20,8 @@ trait DataprocDAO {
 
   def uploadToBucket(googleProject: GoogleProject, bucketName: String, fileName: String, content: String): Future[Unit]
 
+  def bucketObjectExists(googleProject: GoogleProject, bucketName: String, bucketObject: String): Future[Boolean]
+
   def getClusterStatus(googleProject: GoogleProject, clusterName: String)(implicit executionContext: ExecutionContext): Future[LeoClusterStatus]
 
   def getClusterMasterInstanceIp(googleProject: GoogleProject, clusterName: String)(implicit executionContext: ExecutionContext): Future[Option[String]]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
@@ -184,7 +184,7 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig, protected 
   override def bucketObjectExists(googleProject: GoogleProject, bucketName: String, bucketObject: String): Future[Boolean] = {
     val request = storage.objects().get(bucketName, bucketObject)
     executeGoogleRequestAsync(googleProject, bucketName, request).map(_ => true).recover {
-      case e: GoogleJsonResponseException if e.getStatusCode == 404 => false
+      case CallToGoogleApiFailedException(_, _, 404, _) => false
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
@@ -85,7 +85,7 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig, protected 
       .setAllowed(List(allowed).asJava)
   }
 
-  def createCluster(googleProject: GoogleProject, clusterName: String, clusterRequest: ClusterRequest, bucketName: String)(implicit executionContext: ExecutionContext): Future[ClusterResponse] = {
+  override def createCluster(googleProject: GoogleProject, clusterName: String, clusterRequest: ClusterRequest, bucketName: String)(implicit executionContext: ExecutionContext): Future[ClusterResponse] = {
     buildCluster(googleProject, clusterName, clusterRequest, bucketName).map { operation =>
       // Once the cluster creation request is sent to Google, it returns a DataprocOperation, which we transform into a ClusterResponse
       val metadata = operation.getMetadata()
@@ -126,7 +126,7 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig, protected 
   }
 
   /* Check if the given google project has a cluster firewall rule. If not, add the rule to the project*/
-  def updateFirewallRule(googleProject: GoogleProject): Future[Unit] = {
+  override def updateFirewallRule(googleProject: GoogleProject): Future[Unit] = {
     checkFirewallRule(googleProject, dataprocConfig.clusterFirewallRuleName).recoverWith {
       case _: FirewallRuleNotFoundException => addFirewallRule(googleProject)
     }
@@ -150,7 +150,7 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig, protected 
   }
 
   /* Create a bucket in the given google project for the initialization files when creating a cluster */
-  def createBucket(googleProject: GoogleProject, bucketName: String): Future[Unit] = {
+  override def createBucket(googleProject: GoogleProject, bucketName: String): Future[Unit] = {
     // Create lifecycle rule for the bucket that will delete the bucket after 1 day - for now, init buckets will be
     // deleted this way, but eventually we will likely want to delete them after the cluster has been initialized
     val lifecycleRule = new Lifecycle.Rule()
@@ -169,16 +169,23 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig, protected 
   }
 
   /* Upload a file to a bucket as FileContent */
-  def uploadToBucket(googleProject: GoogleProject, bucketName: String, fileName: String, content: File): Future[Unit] = {
+  override def uploadToBucket(googleProject: GoogleProject, bucketName: String, fileName: String, content: File): Future[Unit] = {
     val fileContent = new FileContent(null, content)
     uploadToBucket(googleProject, bucketName, fileName, fileContent).void
   }
 
 
   /* Upload a string to a bucket as InputStreamContent */
-  def uploadToBucket(googleProject: GoogleProject, bucketName: String, fileName: String, content: String): Future[Unit] = {
+  override def uploadToBucket(googleProject: GoogleProject, bucketName: String, fileName: String, content: String): Future[Unit] = {
     val inputStreamContent = new InputStreamContent(null, new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)))
     uploadToBucket(googleProject, bucketName, fileName, inputStreamContent).void
+  }
+
+  override def bucketObjectExists(googleProject: GoogleProject, bucketName: String, bucketObject: String): Future[Boolean] = {
+    val request = storage.objects().get(bucketName, bucketObject)
+    executeGoogleRequestAsync(googleProject, bucketName, request).map(_ => true).recover {
+      case e: GoogleJsonResponseException if e.getStatusCode == 404 => false
+    }
   }
 
   /* Upload the given content into the given bucket */
@@ -195,7 +202,7 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig, protected 
   }
 
   /* Delete a cluster within the google project */
-  def deleteCluster(googleProject: String, clusterName: String)(implicit executionContext: ExecutionContext): Future[Unit] = {
+  override def deleteCluster(googleProject: String, clusterName: String)(implicit executionContext: ExecutionContext): Future[Unit] = {
     val request = dataproc.projects().regions().clusters().delete(googleProject, dataprocConfig.dataprocDefaultRegion, clusterName)
     executeGoogleRequestAsync(googleProject, clusterName, request).recover {
       // treat a 404 error as a successful deletion

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -21,7 +21,7 @@ case class ClusterRecord(id: Long,
                          hostIp: Option[String],
                          createdDate: Timestamp,
                          destroyedDate: Option[Timestamp],
-                         extensionUri: Option[String])
+                         jupyterExtensionUri: Option[String])
 
 trait ClusterComponent extends LeoComponent {
   this: LabelComponent =>
@@ -40,11 +40,11 @@ trait ClusterComponent extends LeoComponent {
     def hostIp =                column[Option[String]]    ("hostIp",                O.Length(254))
     def createdDate =           column[Timestamp]         ("createdDate",           O.SqlType("TIMESTAMP(6)"))
     def destroyedDate =         column[Option[Timestamp]] ("destroyedDate",         O.SqlType("TIMESTAMP(6)"))
-    def extensionUri =          column[Option[String]]    ("extensionUri",          O.Length(254))
+    def jupyterExtensionUri =   column[Option[String]]    ("jupyterExtensionUri",   O.Length(254))
 
     def uniqueKey = index("IDX_CLUSTER_UNIQUE", (googleProject, clusterName), unique = true)
 
-    def * = (id, clusterName, googleId, googleProject, googleServiceAccount, googleBucket, operationName, status, hostIp, createdDate, destroyedDate, extensionUri) <> (ClusterRecord.tupled, ClusterRecord.unapply)
+    def * = (id, clusterName, googleId, googleProject, googleServiceAccount, googleBucket, operationName, status, hostIp, createdDate, destroyedDate, jupyterExtensionUri) <> (ClusterRecord.tupled, ClusterRecord.unapply)
   }
 
   object clusterQuery extends TableQuery(new ClusterTable(_)) {
@@ -128,7 +128,7 @@ trait ClusterComponent extends LeoComponent {
         cluster.hostIp,
         Timestamp.from(cluster.createdDate),
         cluster.destroyedDate map Timestamp.from,
-        cluster.extensionUri
+        cluster.jupyterExtensionUri
       )
     }
 
@@ -159,7 +159,7 @@ trait ClusterComponent extends LeoComponent {
         clusterRecord.createdDate.toInstant,
         clusterRecord.destroyedDate map { _.toInstant },
         labels,
-        clusterRecord.extensionUri
+        clusterRecord.jupyterExtensionUri
       )
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -40,7 +40,7 @@ trait ClusterComponent extends LeoComponent {
     def hostIp =                column[Option[String]]    ("hostIp",                O.Length(254))
     def createdDate =           column[Timestamp]         ("createdDate",           O.SqlType("TIMESTAMP(6)"))
     def destroyedDate =         column[Option[Timestamp]] ("destroyedDate",         O.SqlType("TIMESTAMP(6)"))
-    def jupyterExtensionUri =   column[Option[String]]    ("jupyterExtensionUri",   O.Length(254))
+    def jupyterExtensionUri =   column[Option[String]]    ("jupyterExtensionUri",   O.Length(1024))
 
     def uniqueKey = index("IDX_CLUSTER_UNIQUE", (googleProject, clusterName), unique = true)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -20,7 +20,8 @@ case class ClusterRecord(id: Long,
                          status: String,
                          hostIp: Option[String],
                          createdDate: Timestamp,
-                         destroyedDate: Option[Timestamp])
+                         destroyedDate: Option[Timestamp],
+                         extensionUri: Option[String])
 
 trait ClusterComponent extends LeoComponent {
   this: LabelComponent =>
@@ -39,10 +40,11 @@ trait ClusterComponent extends LeoComponent {
     def hostIp =                column[Option[String]]    ("hostIp",                O.Length(254))
     def createdDate =           column[Timestamp]         ("createdDate",           O.SqlType("TIMESTAMP(6)"))
     def destroyedDate =         column[Option[Timestamp]] ("destroyedDate",         O.SqlType("TIMESTAMP(6)"))
+    def extensionUri =          column[Option[String]]    ("extensionUri",          O.Length(254))
 
     def uniqueKey = index("IDX_CLUSTER_UNIQUE", (googleProject, clusterName), unique = true)
 
-    def * = (id, clusterName, googleId, googleProject, googleServiceAccount, googleBucket, operationName, status, hostIp, createdDate, destroyedDate) <> (ClusterRecord.tupled, ClusterRecord.unapply)
+    def * = (id, clusterName, googleId, googleProject, googleServiceAccount, googleBucket, operationName, status, hostIp, createdDate, destroyedDate, extensionUri) <> (ClusterRecord.tupled, ClusterRecord.unapply)
   }
 
   object clusterQuery extends TableQuery(new ClusterTable(_)) {
@@ -125,7 +127,8 @@ trait ClusterComponent extends LeoComponent {
         cluster.status.toString,
         cluster.hostIp,
         Timestamp.from(cluster.createdDate),
-        cluster.destroyedDate map Timestamp.from
+        cluster.destroyedDate map Timestamp.from,
+        cluster.extensionUri
       )
     }
 
@@ -155,7 +158,8 @@ trait ClusterComponent extends LeoComponent {
         clusterRecord.hostIp,
         clusterRecord.createdDate.toInstant,
         clusterRecord.destroyedDate map { _.toInstant },
-        labels
+        labels,
+        clusterRecord.extensionUri
       )
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -61,7 +61,7 @@ object Cluster {
     createdDate = Instant.now(),
     destroyedDate = None,
     labels = clusterRequest.labels,
-    extensionUri = clusterRequest.extensionUri)
+    jupyterExtensionUri = clusterRequest.jupyterExtensionUri)
 
   def getClusterUrl(googleProject: String, clusterName: String): String = {
     val config = ConfigFactory.parseResources("leonardo.conf").withFallback(ConfigFactory.load())
@@ -82,12 +82,12 @@ case class Cluster(clusterName: String,
                    createdDate: Instant,
                    destroyedDate: Option[Instant],
                    labels: Map[String, String],
-                   extensionUri: Option[GoogleBucketUri])
+                   jupyterExtensionUri: Option[GoogleBucketUri])
 
 case class ClusterRequest(bucketPath: GoogleBucket,
                           serviceAccount: String,
                           labels: Map[String, String],
-                          extensionUri: Option[GoogleBucketUri])
+                          jupyterExtensionUri: Option[GoogleBucketUri])
 
 case class ClusterResponse(clusterName: String,
                            googleProject: GoogleProject,
@@ -112,7 +112,8 @@ object ClusterInitValues {
       GoogleBucketUri(bucketName, dataprocConfig.jupyterProxySiteConfName),
       dataprocConfig.jupyterServerName,
       dataprocConfig.proxyServerName,
-      clusterRequest.extensionUri
+      GoogleBucketUri(bucketName, dataprocConfig.jupyterInstallExtensionScript),
+      clusterRequest.jupyterExtensionUri.getOrElse("")
     )
 
 }
@@ -128,7 +129,8 @@ case class ClusterInitValues(googleProject: GoogleProject,
                              jupyterProxySiteConf: GoogleBucketUri,
                              jupyterServerName: String,
                              proxyServerName: String,
-                             extensionUri: Option[GoogleBucketUri])
+                             jupyterInstallExtensionScript: String,
+                             jupyterExtensionUri: GoogleBucketUri)
 
 
 object FirewallRuleRequest {
@@ -188,7 +190,7 @@ object LeonardoJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val clusterFormat = jsonFormat13(Cluster.apply)
   implicit val clusterRequestFormat = jsonFormat4(ClusterRequest)
   implicit val clusterResponseFormat = jsonFormat6(ClusterResponse)
-  implicit val clusterInitValuesFormat = jsonFormat12(ClusterInitValues.apply)
+  implicit val clusterInitValuesFormat = jsonFormat13(ClusterInitValues.apply)
   implicit val firewallRuleRequestFormat = jsonFormat5(FirewallRuleRequest.apply)
   implicit val storageObjectResponseFormat = jsonFormat3(StorageObjectResponse)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -60,7 +60,8 @@ object Cluster {
     hostIp = None,
     createdDate = Instant.now(),
     destroyedDate = None,
-    labels = clusterRequest.labels)
+    labels = clusterRequest.labels,
+    extensionUri = clusterRequest.extensionUri)
 
   def getClusterUrl(googleProject: String, clusterName: String): String = {
     val config = ConfigFactory.parseResources("leonardo.conf").withFallback(ConfigFactory.load())
@@ -80,11 +81,13 @@ case class Cluster(clusterName: String,
                    hostIp: Option[String],
                    createdDate: Instant,
                    destroyedDate: Option[Instant],
-                   labels: Map[String, String])
+                   labels: Map[String, String],
+                   extensionUri: Option[GoogleBucketUri])
 
 case class ClusterRequest(bucketPath: GoogleBucket,
                           serviceAccount: String,
-                          labels: Map[String, String])
+                          labels: Map[String, String],
+                          extensionUri: Option[GoogleBucketUri])
 
 case class ClusterResponse(clusterName: String,
                            googleProject: GoogleProject,
@@ -96,7 +99,7 @@ case class ClusterResponse(clusterName: String,
 case class ClusterErrorDetails(code: Int, message: Option[String])
 
 object ClusterInitValues {
-  def apply(googleProject: GoogleProject, clusterName: String, bucketName: String, dataprocConfig: DataprocConfig): ClusterInitValues =
+  def apply(googleProject: GoogleProject, clusterName: String, bucketName: String, dataprocConfig: DataprocConfig, clusterRequest: ClusterRequest): ClusterInitValues =
     ClusterInitValues(
       googleProject,
       clusterName,
@@ -108,7 +111,8 @@ object ClusterInitValues {
       GoogleBucketUri(bucketName, dataprocConfig.clusterDockerComposeName),
       GoogleBucketUri(bucketName, dataprocConfig.jupyterProxySiteConfName),
       dataprocConfig.jupyterServerName,
-      dataprocConfig.proxyServerName
+      dataprocConfig.proxyServerName,
+      clusterRequest.extensionUri
     )
 
 }
@@ -123,7 +127,8 @@ case class ClusterInitValues(googleProject: GoogleProject,
                              jupyterDockerCompose: GoogleBucketUri,
                              jupyterProxySiteConf: GoogleBucketUri,
                              jupyterServerName: String,
-                             proxyServerName: String)
+                             proxyServerName: String,
+                             extensionUri: Option[GoogleBucketUri])
 
 
 object FirewallRuleRequest {
@@ -180,10 +185,10 @@ object LeonardoJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
     }
   }
 
-  implicit val clusterFormat = jsonFormat12(Cluster.apply)
-  implicit val clusterRequestFormat = jsonFormat3(ClusterRequest)
+  implicit val clusterFormat = jsonFormat13(Cluster.apply)
+  implicit val clusterRequestFormat = jsonFormat4(ClusterRequest)
   implicit val clusterResponseFormat = jsonFormat6(ClusterResponse)
-  implicit val clusterInitValuesFormat = jsonFormat11(ClusterInitValues.apply)
+  implicit val clusterInitValuesFormat = jsonFormat12(ClusterInitValues.apply)
   implicit val firewallRuleRequestFormat = jsonFormat5(FirewallRuleRequest.apply)
   implicit val storageObjectResponseFormat = jsonFormat3(StorageObjectResponse)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -41,7 +41,7 @@ class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, gdDAO: DataprocDAO,
     case RecreateCluster(cluster) =>
       if (monitorConfig.recreateCluster) {
         logger.info(s"Recreating cluster ${cluster.googleProject}/${cluster.clusterName}...")
-        val clusterRequest = ClusterRequest(cluster.googleBucket, cluster.googleServiceAccount, cluster.labels)
+        val clusterRequest = ClusterRequest(cluster.googleBucket, cluster.googleServiceAccount, cluster.labels, cluster.extensionUri)
         leoService.createCluster(cluster.googleProject, cluster.clusterName, clusterRequest).failed.foreach { e =>
           logger.error("Error occurred recreating cluster", e)
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSupervisor.scala
@@ -41,7 +41,7 @@ class ClusterMonitorSupervisor(monitorConfig: MonitorConfig, gdDAO: DataprocDAO,
     case RecreateCluster(cluster) =>
       if (monitorConfig.recreateCluster) {
         logger.info(s"Recreating cluster ${cluster.googleProject}/${cluster.clusterName}...")
-        val clusterRequest = ClusterRequest(cluster.googleBucket, cluster.googleServiceAccount, cluster.labels, cluster.extensionUri)
+        val clusterRequest = ClusterRequest(cluster.googleBucket, cluster.googleServiceAccount, cluster.labels, cluster.jupyterExtensionUri)
         leoService.createCluster(cluster.googleProject, cluster.clusterName, clusterRequest).failed.foreach { e =>
           logger.error("Error occurred recreating cluster", e)
         }

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -48,6 +48,7 @@ dataproc {
   jupyterRootCaKeyName = "test.key"
   proxySiteConf = "site.conf"
   proxyAuthOpenIdcConf = "auth_openidc.conf"
+  jupyterInstallExtensionScript = "install-jupyter-extension.sh"
 
   clusterUrlBase = "test/"
 

--- a/src/test/resources/test-init-actions.sh
+++ b/src/test/resources/test-init-actions.sh
@@ -3,3 +3,4 @@
 $(clusterName)
 $(googleProject)
 $(jupyterDockerImage)
+$(extensionUri)

--- a/src/test/resources/test-init-actions.sh
+++ b/src/test/resources/test-init-actions.sh
@@ -3,4 +3,4 @@
 $(clusterName)
 $(googleProject)
 $(jupyterDockerImage)
-$(extensionUri)
+$(jupyterExtensionUri)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
@@ -18,7 +18,7 @@ class LeoRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with 
   }
 
   it should "200 when creating and getting cluster" in isolatedDbTest {
-    val newCluster = ClusterRequest("test-bucket-path", "test-service-account", Map[String,String]())
+    val newCluster = ClusterRequest("test-bucket-path", "test-service-account", Map.empty, Some("extension_uri"))
     val googleProject = "test-project"
     val clusterName = "test-cluster"
 
@@ -31,6 +31,7 @@ class LeoRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with 
       val responseCluster = responseAs[Cluster]
       responseCluster.googleBucket shouldEqual "test-bucket-path"
       responseCluster.googleServiceAccount shouldEqual "test-service-account"
+      responseCluster.extensionUri shouldEqual Some("extension_uri")
     }
   }
 
@@ -41,7 +42,7 @@ class LeoRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with 
   }
 
   it should "202 when deleting a cluster" in isolatedDbTest{
-    val newCluster = ClusterRequest("test-bucket-path", "test-service-account", Map.empty)
+    val newCluster = ClusterRequest("test-bucket-path", "test-service-account", Map.empty, None)
     val googleProject = "test-project"
     val clusterName = "test-cluster"
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
@@ -31,7 +31,7 @@ class LeoRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with 
       val responseCluster = responseAs[Cluster]
       responseCluster.googleBucket shouldEqual "test-bucket-path"
       responseCluster.googleServiceAccount shouldEqual "test-service-account"
-      responseCluster.extensionUri shouldEqual Some("extension_uri")
+      responseCluster.jupyterExtensionUri shouldEqual Some("extension_uri")
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutesSpec.scala
@@ -18,7 +18,7 @@ class LeoRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with 
   }
 
   it should "200 when creating and getting cluster" in isolatedDbTest {
-    val newCluster = ClusterRequest("test-bucket-path", "test-service-account", Map.empty, Some("extension_uri"))
+    val newCluster = ClusterRequest("test-bucket-path", "test-service-account", Map.empty, Some(mockGoogleDataprocDAO.extensionUri))
     val googleProject = "test-project"
     val clusterName = "test-cluster"
 
@@ -31,7 +31,7 @@ class LeoRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with 
       val responseCluster = responseAs[Cluster]
       responseCluster.googleBucket shouldEqual "test-bucket-path"
       responseCluster.googleServiceAccount shouldEqual "test-service-account"
-      responseCluster.jupyterExtensionUri shouldEqual Some("extension_uri")
+      responseCluster.jupyterExtensionUri shouldEqual Some(mockGoogleDataprocDAO.extensionUri)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockGoogleDataprocDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockGoogleDataprocDAO.scala
@@ -16,6 +16,7 @@ class MockGoogleDataprocDAO(protected val dataprocConfig: DataprocConfig) extend
   val firewallRules: mutable.Map[GoogleProject, String] = new TrieMap()  // Google Project and Rule Name
   val buckets: mutable.Set[String] = mutable.Set() // Set of bucket names - not keeping track of google projects since it's all in leo's project
   val bucketObjects: mutable.Set[(String, String)] = mutable.Set()  // Set of Bucket Name and File Name
+  val extensionUri = "gs://aBucket/my_extension.tar.gz"
 
 
   private def googleID = UUID.randomUUID().toString
@@ -79,4 +80,7 @@ class MockGoogleDataprocDAO(protected val dataprocConfig: DataprocConfig) extend
     Future.successful(None)
   }
 
+  override def bucketObjectExists(googleProject: GoogleProject, bucketName: String, bucketObject: String): Future[Boolean] = {
+    Future.successful(bucketName == "aBucket" && bucketObject == "my_extension.tar.gz")
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -24,7 +24,8 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike {
       hostIp = Some("numbers.and.dots"),
       createdDate = Instant.now(),
       destroyedDate = None,
-      labels = Map("bam" -> "yes", "vcf" -> "no"))
+      labels = Map("bam" -> "yes", "vcf" -> "no"),
+      extensionUri = None)
 
     val c2 = Cluster(
       clusterName = "name2",
@@ -38,7 +39,8 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike {
       hostIp = None,
       createdDate = Instant.now(),
       destroyedDate = None,
-      labels = Map.empty)
+      labels = Map.empty,
+      extensionUri = Some("extension_uri"))
 
     dbFutureValue { _.clusterQuery.save(c1) } shouldEqual c1
     dbFutureValue { _.clusterQuery.save(c2) } shouldEqual c2
@@ -62,7 +64,8 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike {
       hostIp = Some("1.2.3.4"),
       createdDate = Instant.now(),
       destroyedDate = None,
-      labels = Map.empty)
+      labels = Map.empty,
+      extensionUri = Some("extension_uri"))
     dbFailure { _.clusterQuery.save(c3) } shouldBe a[SQLException]
 
     // googleId unique key test
@@ -79,7 +82,8 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike {
       hostIp = Some("1.2.3.4"),
       createdDate = Instant.now(),
       destroyedDate = None,
-      labels = Map.empty)
+      labels = Map.empty,
+      extensionUri = Some("extension_uri"))
     dbFailure { _.clusterQuery.save(c4) } shouldBe a[SQLException]
 
     dbFutureValue { _.clusterQuery.markPendingDeletion(c1.googleId) } shouldEqual 1

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -25,7 +25,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike {
       createdDate = Instant.now(),
       destroyedDate = None,
       labels = Map("bam" -> "yes", "vcf" -> "no"),
-      extensionUri = None)
+      jupyterExtensionUri = None)
 
     val c2 = Cluster(
       clusterName = "name2",
@@ -40,7 +40,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike {
       createdDate = Instant.now(),
       destroyedDate = None,
       labels = Map.empty,
-      extensionUri = Some("extension_uri"))
+      jupyterExtensionUri = Some("extension_uri"))
 
     dbFutureValue { _.clusterQuery.save(c1) } shouldEqual c1
     dbFutureValue { _.clusterQuery.save(c2) } shouldEqual c2
@@ -65,7 +65,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike {
       createdDate = Instant.now(),
       destroyedDate = None,
       labels = Map.empty,
-      extensionUri = Some("extension_uri"))
+      jupyterExtensionUri = Some("extension_uri"))
     dbFailure { _.clusterQuery.save(c3) } shouldBe a[SQLException]
 
     // googleId unique key test
@@ -83,7 +83,7 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike {
       createdDate = Instant.now(),
       destroyedDate = None,
       labels = Map.empty,
-      extensionUri = Some("extension_uri"))
+      jupyterExtensionUri = Some("extension_uri"))
     dbFailure { _.clusterQuery.save(c4) } shouldBe a[SQLException]
 
     dbFutureValue { _.clusterQuery.markPendingDeletion(c1.googleId) } shouldEqual 1

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/LabelComponentSpec.scala
@@ -25,7 +25,8 @@ class LabelComponentSpec extends TestComponent with FlatSpecLike {
       hostIp = None,
       createdDate = Instant.now(),
       destroyedDate = Option(Instant.now()),
-      labels = Map.empty)
+      labels = Map.empty,
+      Some("extension_uri"))
 
     val c2 = Cluster(
       clusterName = "name2",
@@ -39,7 +40,8 @@ class LabelComponentSpec extends TestComponent with FlatSpecLike {
       hostIp = Some("sure, this is an IP address"),
       createdDate = Instant.now(),
       destroyedDate = None,
-      labels = Map.empty)
+      labels = Map.empty,
+      None)
 
     val c2Map = Map("bam" -> "true", "sample" -> "NA12878")
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/ClusterDnsCacheSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dns/ClusterDnsCacheSpec.scala
@@ -41,7 +41,8 @@ class ClusterDnsCacheSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     hostIp = Some("numbers.and.dots"),
     createdDate = Instant.now(),
     destroyedDate = None,
-    labels = Map("bam" -> "yes", "vcf" -> "no"))
+    labels = Map("bam" -> "yes", "vcf" -> "no"),
+    Some("extension_uri"))
 
   val c2 = Cluster(
     clusterName = "name2",
@@ -55,7 +56,8 @@ class ClusterDnsCacheSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     hostIp = None,
     createdDate = Instant.now(),
     destroyedDate = None,
-    labels = Map.empty)
+    labels = Map.empty,
+    None)
 
   it should "update maps and return clusters" in isolatedDbTest {
     val actorRef = TestActorRef[ClusterDnsCache](ClusterDnsCache.props(proxyConfig, DbSingleton.ref))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -43,7 +43,8 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     hostIp = None,
     createdDate = Instant.now(),
     destroyedDate = None,
-    labels = Map("bam" -> "yes", "vcf" -> "no"))
+    labels = Map("bam" -> "yes", "vcf" -> "no"),
+    None)
 
   val deletingCluster = Cluster(
     clusterName = "name2",
@@ -57,7 +58,8 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     hostIp = None,
     createdDate = Instant.now(),
     destroyedDate = None,
-    labels = Map("bam" -> "yes", "vcf" -> "no"))
+    labels = Map("bam" -> "yes", "vcf" -> "no"),
+    Some("clsuter_uri"))
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -35,7 +35,7 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   private val testClusterRequest = ClusterRequest(bucketPath, serviceAccount, Map.empty, Some(extensionUri))
 
   val initFiles = Array( dataprocConfig.clusterDockerComposeName, dataprocConfig.initActionsScriptName, dataprocConfig.jupyterServerCrtName,
-    dataprocConfig.jupyterServerKeyName, dataprocConfig.jupyterRootCaPemName, dataprocConfig.jupyterProxySiteConfName)
+    dataprocConfig.jupyterServerKeyName, dataprocConfig.jupyterRootCaPemName, dataprocConfig.jupyterProxySiteConfName, dataprocConfig.jupyterInstallExtensionScript)
 
   "LeonardoService" should "create a cluster" in isolatedDbTest {
     // set unique names for our cluster and google project

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -215,4 +215,17 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
 
     result shouldEqual expected
   }
+
+  it should "throw a BucketPathTooLongException when the extensionUri is too long" in isolatedDbTest {
+    val jupyterExtensionUri = Stream.continually('a').take(1025).mkString
+
+    // set unique names for our cluster and google project
+    val clusterName = s"cluster-${UUID.randomUUID.toString}"
+    val googleProject = s"project-${UUID.randomUUID.toString}"
+
+    // create the cluster
+    intercept[BucketPathTooLongException] {
+      leo.createCluster(googleProject, clusterName, testClusterRequest.copy(jupyterExtensionUri = Some(jupyterExtensionUri))).futureValue
+    }
+  }
 }


### PR DESCRIPTION
https://broadinstitute.atlassian.net/browse/GAWB-2535

Depends heavily on: https://github.com/broadinstitute/firecloud-develop/pull/659

Basic flow:
1. Cluster PUT request accepts an optional gs:// path to a tar.gz containing extension files
   - For testing I've been using: `gs://rtitle-jupyter-extension/my_extension.tar.gz`
2. The gs:// path gets saved in the CLUSTER table in a new column
3. The gs:// path is templated into the init-actions.sh script
4. init-actions.sh copies the tarball to the local VM using `gsutil cp`
5. `cluster-docker-compose.yml` mounts the tarball inside the jupyter docker container
6. init-actions.sh calls `install-jupyter-extension.sh` on the jupyter-server docker via `docker exec`
   - I didn't see a good way of doing this in the docker-compose, i.e. running an arbitrary command after the container is run. But docker exec works.
7. `install-jupyter-extension.sh` extracts the tarball to the right place, and runs the necessary `jupyter nbextension install|enable` commands
8. Notebooks now have the AoU logo

Whew! I considered a slightly different way of doing this by passing args to the jupyter Dockerfile. But this way seemed less risky to me.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
