### PR TITLE
Add cluster status enums to Swagger

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -246,6 +246,16 @@ paths:
 ## DEFINITIONS
 ##########################################################################################
 definitions:
+  ClusterStatus:
+    type: string
+    enum: &CLUSTERSTATUS
+      - Creating
+      - Running
+      - Updating
+      - Error
+      - Deleting
+      - Deleted
+      - Unknown
   ErrorReport:
     description: ''
     required:
@@ -329,6 +339,7 @@ definitions:
         description: Google's operation ID for the cluster
       status:
         type: string
+        enum: *CLUSTERSTATUS
         description: The current state of the cluster
       hostIp:
         type: string

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -29,6 +29,7 @@ object GoogleBucketUri {
 
 object ClusterStatus extends Enumeration {
   type ClusterStatus = Value
+  //NOTE: Remember to update the definition of this enum in Swagger when you add new ones
   val Unknown, Creating, Running, Updating, Error, Deleting, Deleted = Value
   val activeStatuses = Set(Unknown, Creating, Running, Updating)
   val monitoredStatuses = Set(Unknown, Creating, Updating, Deleting)


### PR DESCRIPTION
It doesn't look great in the Swagger UI rendering but it's there now. On request of the AoU folks.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
