### PR TITLE
GAWB - 2627 - Allow multiple clusters with same name

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -8,4 +8,5 @@
     <include file="changesets/20170918_cluster-jupyterExtensionUri-column.xml" relativeToChangelogFile="true" />
     <include file="changesets/20171002_cluster-init-bucket-column.xml" relativeToChangelogFile="true" />
     <include file="changesets/20171010_cluster_unique_index.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20171011_cluster_destroyedDate_not_null.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changelog.xml
@@ -7,4 +7,5 @@
     <include file="changesets/20170901_cluster-createdDate-default.xml" relativeToChangelogFile="true" />
     <include file="changesets/20170918_cluster-jupyterExtensionUri-column.xml" relativeToChangelogFile="true" />
     <include file="changesets/20171002_cluster-init-bucket-column.xml" relativeToChangelogFile="true" />
+    <include file="changesets/20171010_cluster_unique_index.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20170811_cluster-unique-key.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20170811_cluster-unique-key.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <changeSet logicalFilePath="leonardo" author="thibault" id="cluster-unique-key">
-        <addUniqueConstraint columnNames="googleProject, clusterName" constraintName="IDX_CLUSTER_UNIQUE" tableName="CLUSTER"/>
+        <addUniqueConstraint columnNames="googleProject, clusterName, destroyedDate" constraintName="IDX_CLUSTER_UNIQUE" tableName="CLUSTER"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20171010_cluster_unique_index.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20171010_cluster_unique_index.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-    <changeSet logicalFilePath="leonardo" author="thibault" id="cluster-unique-key">
-        <addUniqueConstraint columnNames="googleProject, clusterName" constraintName="IDX_CLUSTER_UNIQUE" tableName="CLUSTER"/>
+    <changeSet logicalFilePath="leonardo" author="vkumra" id="update_cluster-unique-key">
+        <dropIndex indexName="IDX_CLUSTER_UNIQUE" tableName="CLUSTER"/>
+        <addUniqueConstraint columnNames="googleProject, clusterName, destroyedDate" constraintName="IDX_CLUSTER_UNIQUE" tableName="CLUSTER"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20171011_cluster_destroyedDate_not_null.xml
+++ b/src/main/resources/org/broadinstitute/dsde/workbench/leonardo/liquibase/changesets/20171011_cluster_destroyedDate_not_null.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="leonardo" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="leonardo" author="vkumra" id="cluster_destroyeddate_not_null">
+        <addNotNullConstraint columnDataType="TIMESTAMP(6)"
+                              columnName="destroyedDate"
+                              defaultNullValue="1970-01-01 00:00:01.000000"
+                              tableName="CLUSTER"/>
+        <addDefaultValue columnDataType="TIMESTAMP(6)"
+                         columnName="destroyedDate"
+                         defaultValue="1970-01-01 00:00:01.000000"
+                         tableName="CLUSTER"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
@@ -47,7 +47,7 @@ class LeoRoutes(val leonardoService: LeonardoService, val proxyService: ProxySer
       } ~
       get {
         complete {
-          leonardoService.getClusterDetails(GoogleProject(googleProject), ClusterName(clusterName)). map { clusterDetails =>
+          leonardoService.getActiveClusterDetails(GoogleProject(googleProject), ClusterName(clusterName)). map { clusterDetails =>
             StatusCodes.OK -> clusterDetails
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -86,6 +86,12 @@ trait ClusterComponent extends LeoComponent {
       }
     }
 
+    def getDeletingClusterByName(project: GoogleProject, name: ClusterName): DBIO[Option[Cluster]] = {
+      clusterQueryWithLabels.filter { _._1.googleProject === project.string }.filter { _._1.clusterName === name.string }.filter{_._1.status === ClusterStatus.Deleting.toString}.result map { recs =>
+        unmarshalClustersWithLabels(recs).headOption
+      }
+    }
+
     def getByGoogleId(googleId: UUID): DBIO[Option[Cluster]] = {
       clusterQueryWithLabels.filter { _._1.googleId === googleId }.result map { recs =>
         unmarshalClustersWithLabels(recs).headOption

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponent.scala
@@ -1,4 +1,5 @@
 package org.broadinstitute.dsde.workbench.leonardo.db
+import java.time.Instant
 
 import java.sql.Timestamp
 import java.util.UUID
@@ -21,7 +22,7 @@ case class ClusterRecord(id: Long,
                          status: String,
                          hostIp: Option[String],
                          createdDate: Timestamp,
-                         destroyedDate: Option[Timestamp],
+                         destroyedDate: Timestamp,
                          jupyterExtensionUri: Option[String],
                          initBucket: String)
 
@@ -41,7 +42,7 @@ trait ClusterComponent extends LeoComponent {
     def status =                column[String]            ("status",                O.Length(254))
     def hostIp =                column[Option[String]]    ("hostIp",                O.Length(254))
     def createdDate =           column[Timestamp]         ("createdDate",           O.SqlType("TIMESTAMP(6)"))
-    def destroyedDate =         column[Option[Timestamp]] ("destroyedDate",         O.SqlType("TIMESTAMP(6)"))
+    def destroyedDate =         column[Timestamp]         ("destroyedDate",         O.SqlType("TIMESTAMP(6)"))
     def jupyterExtensionUri =   column[Option[String]]    ("jupyterExtensionUri",   O.Length(1024))
     def initBucket =            column[String]            ("initBucket",            O.Length(1024))
 
@@ -52,6 +53,7 @@ trait ClusterComponent extends LeoComponent {
 
   object clusterQuery extends TableQuery(new ClusterTable(_)) {
 
+    private lazy val dummyDate:String = "1970-01-01T00:00:01.000Z"
     def save(cluster: Cluster, initBucket: GcsPath): DBIO[Cluster] = {
       (clusterQuery returning clusterQuery.map(_.id) += marshalCluster(cluster, initBucket.toUri)) flatMap { clusterId =>
         labelQuery.saveAllForCluster(clusterId, cluster.labels)
@@ -78,8 +80,8 @@ trait ClusterComponent extends LeoComponent {
       clusterQueryWithLabels.filter { _._1.googleProject === project.string }.filter { _._1.clusterName === name.string }
     }
 
-    def getByName(project: GoogleProject, name: ClusterName): DBIO[Option[Cluster]] = {
-      findByName(project, name).result map { recs =>
+    def getActiveClusterByName(project: GoogleProject, name: ClusterName): DBIO[Option[Cluster]] = {
+      clusterQueryWithLabels.filter { _._1.googleProject === project.string }.filter { _._1.clusterName === name.string }.filter{_._1.destroyedDate === Timestamp.from(Instant.parse(dummyDate))}.result map { recs =>
         unmarshalClustersWithLabels(recs).headOption
       }
     }
@@ -103,15 +105,11 @@ trait ClusterComponent extends LeoComponent {
     def markPendingDeletion(googleId: UUID): DBIO[Int] = {
       clusterQuery.filter(_.googleId === googleId)
         .map(c => (c.destroyedDate, c.status, c.hostIp))
-        .update((Option(Timestamp.from(java.time.Instant.now())), ClusterStatus.Deleting.toString, None))
+        .update(Timestamp.from(java.time.Instant.now()), ClusterStatus.Deleting.toString, None)
     }
 
     def completeDeletion(googleId: UUID, clusterName: ClusterName): DBIO[Int] = {
-      updateClusterStatus(googleId, ClusterStatus.Deleted) andThen
-        // Append a random suffix to the cluster name to prevent unique key conflicts in case a cluster
-        // with the same name is recreated.
-        // TODO: This is a bit ugly; a better solution would be to have a unique key on (googleId, clusterName, destroyedDate)
-        updateClusterName(googleId, appendRandomSuffix(clusterName.string))
+      updateClusterStatus(googleId, ClusterStatus.Deleted)
     }
 
     def setToRunning(googleId: UUID, hostIp: IP): DBIO[Int] = {
@@ -176,7 +174,7 @@ trait ClusterComponent extends LeoComponent {
         cluster.status.toString,
         cluster.hostIp map(_.string),
         Timestamp.from(cluster.createdDate),
-        cluster.destroyedDate map Timestamp.from,
+        Timestamp.from(cluster.destroyedDate.getOrElse(Instant.parse(dummyDate))),
         cluster.jupyterExtensionUri map(_.toUri),
         initBucket
       )
@@ -209,12 +207,18 @@ trait ClusterComponent extends LeoComponent {
         ClusterStatus.withName(clusterRecord.status),
         clusterRecord.hostIp map IP,
         clusterRecord.createdDate.toInstant,
-        clusterRecord.destroyedDate map { _.toInstant },
+        getDestroyedDate(clusterRecord.destroyedDate),
         labels,
         clusterRecord.jupyterExtensionUri flatMap { GcsPath.parse(_).toOption }
       )
     }
 
+    private def getDestroyedDate(destroyedDate:Timestamp): Option[Instant] = {
+      if(destroyedDate.toInstant != Instant.parse((dummyDate)))
+        Some(destroyedDate.toInstant)
+      else
+        None
+    }
     private def updateClusterName(googleId: UUID, newName: String): DBIO[Int] = {
       clusterQuery.filter { _.googleId === googleId }.map(_.clusterName).update(newName)
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -61,12 +61,6 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig, gdDAO: Datap
     }
   }
 
-  /*def getClusterDetails(googleProject: GoogleProject, clusterName: ClusterName): Future[Cluster] = {
-    dbRef.inTransaction { dataAccess =>
-      getCluster(googleProject, clusterName, dataAccess)
-    }
-  }*/
-
   def getActiveClusterDetails(googleProject: GoogleProject, clusterName: ClusterName): Future[Cluster] = {
     dbRef.inTransaction { dataAccess =>
       getActiveCluster(googleProject, clusterName, dataAccess)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -51,7 +51,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig, gdDAO: Datap
 
     // Check if the google project has a cluster with the same name. If not, we can create it
     dbRef.inTransaction { dataAccess =>
-      dataAccess.clusterQuery.getByName(googleProject, clusterName)
+      dataAccess.clusterQuery.getActiveClusterByName(googleProject, clusterName)
     } flatMap {
       case Some(_) => throw ClusterAlreadyExistsException(googleProject, clusterName)
       case None =>
@@ -61,14 +61,20 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig, gdDAO: Datap
     }
   }
 
-  def getClusterDetails(googleProject: GoogleProject, clusterName: ClusterName): Future[Cluster] = {
+  /*def getClusterDetails(googleProject: GoogleProject, clusterName: ClusterName): Future[Cluster] = {
     dbRef.inTransaction { dataAccess =>
       getCluster(googleProject, clusterName, dataAccess)
+    }
+  }*/
+
+  def getActiveClusterDetails(googleProject: GoogleProject, clusterName: ClusterName): Future[Cluster] = {
+    dbRef.inTransaction { dataAccess =>
+      getActiveCluster(googleProject, clusterName, dataAccess)
     }
   }
 
   def deleteCluster(googleProject: GoogleProject, clusterName: ClusterName): Future[Int] = {
-    getClusterDetails(googleProject, clusterName) flatMap { cluster =>
+    getActiveClusterDetails(googleProject, clusterName) flatMap { cluster =>
       if(cluster.status.isActive) {
         for {
           _ <- gdDAO.deleteCluster(googleProject, clusterName)
@@ -89,12 +95,15 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig, gdDAO: Datap
    }
   }
 
-  private[service] def getCluster(googleProject: GoogleProject, clusterName: ClusterName, dataAccess: DataAccess): DBIO[Cluster] = {
-    dataAccess.clusterQuery.getByName(googleProject, clusterName) flatMap {
+
+  private[service] def getActiveCluster(googleProject: GoogleProject, clusterName: ClusterName, dataAccess: DataAccess): DBIO[Cluster] = {
+    dataAccess.clusterQuery.getActiveClusterByName(googleProject, clusterName) flatMap {
       case None => throw ClusterNotFoundException(googleProject, clusterName)
       case Some(cluster) => DBIO.successful(cluster)
     }
   }
+
+
 
   /* Creates a cluster in the given google project:
      - Add a firewall rule to the user's google project if it doesn't exist, so we can access the cluster

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/ClusterComponentSpec.scala
@@ -47,8 +47,8 @@ class ClusterComponentSpec extends TestComponent with FlatSpecLike with CommonTe
     dbFutureValue { _.clusterQuery.save(c1, gcsPath("gs://bucket1")) } shouldEqual c1
     dbFutureValue { _.clusterQuery.save(c2, gcsPath("gs://bucket2")) } shouldEqual c2
     dbFutureValue { _.clusterQuery.list() } should contain theSameElementsAs Seq(c1, c2)
-    dbFutureValue { _.clusterQuery.getByName(c1.googleProject, c1.clusterName) } shouldEqual Some(c1)
-    dbFutureValue { _.clusterQuery.getByName(c1.googleProject, c2.clusterName) } shouldEqual Some(c2)
+    dbFutureValue { _.clusterQuery.getActiveClusterByName(c1.googleProject, c1.clusterName) } shouldEqual Some(c1)
+    dbFutureValue { _.clusterQuery.getActiveClusterByName(c1.googleProject, c2.clusterName) } shouldEqual Some(c2)
     dbFutureValue { _.clusterQuery.getByGoogleId(c1.googleId) } shouldEqual Some(c1)
     dbFutureValue { _.clusterQuery.getByGoogleId(c2.googleId) } shouldEqual Some(c2)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/monitor/ClusterMonitorSpec.scala
@@ -98,7 +98,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     createClusterSupervisor(dao) ! ClusterCreated(creatingCluster)
 
     expectMsgClass(1 second, classOf[Terminated])
-    val updatedCluster = dbFutureValue { _.clusterQuery.getByName(creatingCluster.googleProject, creatingCluster.clusterName) }
+    val updatedCluster = dbFutureValue { _.clusterQuery.getActiveClusterByName(creatingCluster.googleProject, creatingCluster.clusterName) }
     updatedCluster shouldBe 'defined
     updatedCluster.map(_.status) shouldBe Some(ClusterStatus.Running)
     updatedCluster.flatMap(_.hostIp) shouldBe Some(IP("1.2.3.4"))
@@ -125,7 +125,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
 
       expectNoMsg(1 second)
 
-      val updatedCluster = dbFutureValue { _.clusterQuery.getByName(creatingCluster.googleProject, creatingCluster.clusterName) }
+      val updatedCluster = dbFutureValue { _.clusterQuery.getActiveClusterByName(creatingCluster.googleProject, creatingCluster.clusterName) }
       updatedCluster shouldBe 'defined
       updatedCluster shouldBe Some(creatingCluster)
 
@@ -155,7 +155,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
 
     expectNoMsg(1 second)
 
-    val updatedCluster = dbFutureValue { _.clusterQuery.getByName(creatingCluster.googleProject, creatingCluster.clusterName) }
+    val updatedCluster = dbFutureValue { _.clusterQuery.getActiveClusterByName(creatingCluster.googleProject, creatingCluster.clusterName) }
     updatedCluster shouldBe 'defined
     updatedCluster shouldBe Some(creatingCluster)
 
@@ -184,7 +184,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
 
     expectNoMsg(1 second)
 
-    val updatedCluster = dbFutureValue { _.clusterQuery.getByName(creatingCluster.googleProject, creatingCluster.clusterName) }
+    val updatedCluster = dbFutureValue { _.clusterQuery.getActiveClusterByName(creatingCluster.googleProject, creatingCluster.clusterName) }
     updatedCluster shouldBe 'defined
     updatedCluster shouldBe Some(creatingCluster)
 
@@ -216,7 +216,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     createClusterSupervisor(dao) ! ClusterCreated(creatingCluster)
 
     expectMsgClass(1 second, classOf[Terminated])
-    val updatedCluster = dbFutureValue { _.clusterQuery.getByName(creatingCluster.googleProject, creatingCluster.clusterName) }
+    val updatedCluster = dbFutureValue { _.clusterQuery.getActiveClusterByName(creatingCluster.googleProject, creatingCluster.clusterName) }
     updatedCluster shouldBe 'defined
     updatedCluster.map(_.status) shouldBe Some(ClusterStatus.Error)
     updatedCluster.flatMap(_.hostIp) shouldBe None
@@ -327,9 +327,8 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
     oldCluster.map(_.status) shouldBe Some(ClusterStatus.Deleted)
     oldCluster.flatMap(_.hostIp) shouldBe None
 
-    val newCluster = dbFutureValue { _.clusterQuery.getByName(creatingCluster.googleProject, creatingCluster.clusterName) }
+    val newCluster = dbFutureValue { _.clusterQuery.getActiveClusterByName(creatingCluster.googleProject, creatingCluster.clusterName) }
     val newClusterBucket = dbFutureValue { _.clusterQuery.getInitBucket(creatingCluster.googleProject, creatingCluster.clusterName.string) }
-
     newCluster shouldBe 'defined
     newClusterBucket shouldBe 'defined
 
@@ -358,7 +357,7 @@ class ClusterMonitorSpec extends TestKit(ActorSystem("leonardotest")) with FlatS
 
     expectNoMsg(1 second)
 
-    val updatedCluster = dbFutureValue { _.clusterQuery.getByName(deletingCluster.googleProject, deletingCluster.clusterName) }
+    val updatedCluster = dbFutureValue { _.clusterQuery.getDeletingClusterByName(deletingCluster.googleProject, deletingCluster.clusterName) }
     updatedCluster shouldBe 'defined
     updatedCluster shouldBe Some(deletingCluster)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -95,6 +95,26 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     }
   }
 
+  it should "create two clusters with same name with only one active" in isolatedDbTest {
+    //create first cluster
+    leo.createCluster(googleProject, clusterName, testClusterRequest).futureValue
+
+    // check that the cluster was created
+    gdDAO.clusters should contain key (clusterName)
+
+    // delete the cluster
+    val clusterDeleteResponse = leo.deleteCluster(googleProject, clusterName).futureValue
+
+    // the delete response should indicate 1 cluster was deleted
+    clusterDeleteResponse shouldEqual 1
+
+    //recreate cluster with same project and cluster name
+    leo.createCluster(googleProject, clusterName, testClusterRequest).futureValue
+
+    //confirm cluster was created
+    gdDAO.clusters should contain key (clusterName)
+  }
+
   it should "delete a cluster" in isolatedDbTest {
     // check that the cluster does not exist
     gdDAO.clusters should not contain key (clusterName)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -73,14 +73,14 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
     val clusterCreateResponse = leo.createCluster(googleProject, clusterName, testClusterRequest).futureValue
 
     // get the cluster detail
-    val clusterGetResponse = leo.getClusterDetails(googleProject, clusterName).futureValue
+    val clusterGetResponse = leo.getActiveClusterDetails(googleProject, clusterName).futureValue
 
     // check the create response and get response are the same
     clusterCreateResponse shouldEqual clusterGetResponse
   }
 
   it should "throw ClusterNotFoundException for nonexistent clusters" in isolatedDbTest {
-    whenReady( leo.getClusterDetails(GoogleProject("nonexistent"), ClusterName("cluster")).failed ) { exc =>
+    whenReady( leo.getActiveClusterDetails(GoogleProject("nonexistent"), ClusterName("cluster")).failed ) { exc =>
       exc shouldBe a [ClusterNotFoundException]
     }
   }


### PR DESCRIPTION
Updated the unique constraint to include destroyed date. Added default destroyed date on cluster create. Only one cluster is active at a time. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
