### PR TITLE
Don't need to info log on every request

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
@@ -62,7 +62,6 @@ class LeoRoutes(val leonardoService: LeonardoService, val proxyService: ProxySer
   } ~
   path("clusters") {
     parameterMap { params =>
-      logger.info(params.toString)
       complete {
         leonardoService.listClusters(params).map { clusters =>
           StatusCodes.OK -> clusters


### PR DESCRIPTION
I noticed a lot of INFO spam while ssh'ed in to Leo. I don't think we should log the params on every request to `GET /api/cluster`.

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
