### PR TITLE
Add basic UserInfo checking to Leo. This is not actually used yet.

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/Boot.scala
@@ -6,7 +6,7 @@ import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import net.ceedubs.ficus.Ficus._
-import org.broadinstitute.dsde.workbench.leonardo.api.LeoRoutes
+import org.broadinstitute.dsde.workbench.leonardo.api.{LeoRoutes, StandardUserInfoDirectives}
 import org.broadinstitute.dsde.workbench.leonardo.config.{ClusterResourcesConfig, DataprocConfig, MonitorConfig, ProxyConfig, SwaggerConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.GoogleDataprocDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.DbReference
@@ -56,7 +56,7 @@ object Boot extends App with LazyLogging {
     val leonardoService = new LeonardoService(dataprocConfig, clusterResourcesConfig, proxyConfig, gdDAO, dbRef, clusterMonitorSupervisor)
     val clusterDnsCache = system.actorOf(ClusterDnsCache.props(proxyConfig, dbRef))
     val proxyService = new ProxyService(proxyConfig, dbRef, clusterDnsCache)
-    val leoRoutes = new LeoRoutes(leonardoService, proxyService, config.as[SwaggerConfig]("swagger"))
+    val leoRoutes = new LeoRoutes(leonardoService, proxyService, config.as[SwaggerConfig]("swagger")) with StandardUserInfoDirectives
 
     startClusterMonitors(dbRef, clusterMonitorSupervisor)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/StandardUserInfoDirectives.scala
@@ -1,0 +1,21 @@
+package org.broadinstitute.dsde.workbench.leonardo.api
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.server.Directive1
+import akka.http.scaladsl.server.Directives.headerValueByName
+import org.broadinstitute.dsde.workbench.leonardo.model.UserInfo
+import org.broadinstitute.dsde.workbench.model.{WorkbenchUserEmail, WorkbenchUserId}
+
+/**
+  * Created by rtitle on 10/16/17.
+  */
+trait StandardUserInfoDirectives extends UserInfoDirectives {
+  override def requireUserInfo: Directive1[UserInfo] = {
+    (headerValueByName("OIDC_access_token") &
+     headerValueByName("OIDC_CLAIM_user_id") &
+     headerValueByName("OIDC_CLAIM_expires_in") &
+     headerValueByName("OIDC_CLAIM_email")).tmap { case (token, userId, expiresIn, email) =>
+      UserInfo(OAuth2BearerToken(token), WorkbenchUserId(userId), WorkbenchUserEmail(email), expiresIn.toLong)
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/UserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/UserInfoDirectives.scala
@@ -1,0 +1,11 @@
+package org.broadinstitute.dsde.workbench.leonardo.api
+
+import akka.http.scaladsl.server.Directive1
+import org.broadinstitute.dsde.workbench.leonardo.model.UserInfo
+
+/**
+  * Created by rtitle on 10/16/17.
+  */
+trait UserInfoDirectives {
+  def requireUserInfo: Directive1[UserInfo]
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/UserInfo.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/UserInfo.scala
@@ -1,0 +1,9 @@
+package org.broadinstitute.dsde.workbench.leonardo.model
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import org.broadinstitute.dsde.workbench.model.{WorkbenchUserEmail, WorkbenchUserId}
+
+/**
+  * Created by rtitle on 10/16/17.
+  */
+case class UserInfo(accessToken: OAuth2BearerToken, userId: WorkbenchUserId, userEmail: WorkbenchUserEmail, tokenExpiresIn: Long)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/MockUserInfoDirectives.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/MockUserInfoDirectives.scala
@@ -1,0 +1,14 @@
+package org.broadinstitute.dsde.workbench.leonardo.api
+
+import akka.http.scaladsl.server.Directive1
+import akka.http.scaladsl.server.Directives.provide
+import org.broadinstitute.dsde.workbench.leonardo.model.UserInfo
+
+/**
+  * Created by rtitle on 10/16/17.
+  */
+trait MockUserInfoDirectives extends UserInfoDirectives {
+  val userInfo: UserInfo
+
+  override def requireUserInfo: Directive1[UserInfo] = provide(userInfo)
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/api/TestLeoRoutes.scala
@@ -1,16 +1,16 @@
 package org.broadinstitute.dsde.workbench.leonardo.api
 
-import akka.actor.{Actor, Props}
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.leonardo.config.{ClusterResourcesConfig, DataprocConfig, ProxyConfig, SwaggerConfig}
 import org.broadinstitute.dsde.workbench.leonardo.dao.MockGoogleDataprocDAO
 import org.broadinstitute.dsde.workbench.leonardo.db.DbSingleton
+import org.broadinstitute.dsde.workbench.leonardo.model.UserInfo
 import org.broadinstitute.dsde.workbench.leonardo.monitor.NoopActor
 import org.broadinstitute.dsde.workbench.leonardo.service.{LeonardoService, MockProxyService}
-
-import scala.concurrent.duration._
+import org.broadinstitute.dsde.workbench.model.{WorkbenchUserEmail, WorkbenchUserId}
 
 /**
   * Created by rtitle on 8/15/17.
@@ -26,5 +26,8 @@ trait TestLeoRoutes { this: ScalatestRouteTest =>
   val leonardoService = new LeonardoService(dataprocConfig, clusterResourcesConfig, proxyConfig, mockGoogleDataprocDAO, DbSingleton.ref, clusterMonitorSupervisor)
   val proxyService = new MockProxyService(proxyConfig, DbSingleton.ref)
   val swaggerConfig = SwaggerConfig("", "")
-  val leoRoutes = new LeoRoutes(leonardoService, proxyService, swaggerConfig)
+  val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchUserEmail("user1@example.com"), 0)
+  val leoRoutes = new LeoRoutes(leonardoService, proxyService, swaggerConfig) with MockUserInfoDirectives {
+    override val userInfo: UserInfo = defaultUserInfo
+  }
 }


### PR DESCRIPTION
Added `UserInfo` case class and `UserInfoDirectives` which extracts UserInfo's out of Leo http requests. This is not actually used yet, but will be needed in the future for whitelist auth and pet service accounts.

I code-borrowed pretty heavily from Sam. It works locally.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
