### PR TITLE
Set OAuth2 scopes on cluster creation, and don't send the sa key json to the cluster

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/api/LeoRoutes.scala
@@ -45,19 +45,19 @@ abstract class LeoRoutes(val leonardoService: LeonardoService, val proxyService:
               }
             }
           }
-        }
-      } ~
-      get {
-        complete {
-          leonardoService.getActiveClusterDetails(GoogleProject(googleProject), ClusterName(clusterName)). map { clusterDetails =>
-            StatusCodes.OK -> clusterDetails
+        } ~
+        get {
+          complete {
+            leonardoService.getActiveClusterDetails(GoogleProject(googleProject), ClusterName(clusterName)).map { clusterDetails =>
+              StatusCodes.OK -> clusterDetails
+            }
           }
-        }
-      } ~
-      delete {
-        complete {
-          leonardoService.deleteCluster(GoogleProject(googleProject), ClusterName(clusterName)).map { _ =>
-            StatusCodes.Accepted
+        } ~
+        delete {
+          complete {
+            leonardoService.deleteCluster(GoogleProject(googleProject), ClusterName(clusterName)).map { _ =>
+              StatusCodes.Accepted
+            }
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ClusterResourcesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/ClusterResourcesConfig.scala
@@ -10,6 +10,5 @@ case class ClusterResourcesConfig(
                                    jupyterRootCaPem: String,
                                    jupyterRootCaKey: String,
                                    jupyterProxySiteConf: String,
-                                   jupyterInstallExtensionScript: String,
-                                   userServiceAccountCredentials: String
+                                   jupyterInstallExtensionScript: String
                                  )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/package.scala
@@ -5,9 +5,6 @@ import net.ceedubs.ficus.readers.ValueReader
 import org.broadinstitute.dsde.workbench.leonardo.model.{GoogleProject, GoogleServiceAccount}
 import org.broadinstitute.dsde.workbench.util.toScalaDuration
 
-import java.io.File
-
-
 package object config {
   implicit val swaggerReader: ValueReader[SwaggerConfig] = ValueReader.relative { config =>
     SwaggerConfig(
@@ -39,8 +36,7 @@ package object config {
       config.getString("jupyterRootCaPem"),
       config.getString("jupyterRootCaKey"),
       config.getString("proxySiteConf"),
-      config.getString("jupyterInstallExtensionScript"),
-      config.getString("userServiceAccountCredentials"))
+      config.getString("jupyterInstallExtensionScript"))
   }
 
   implicit val liquibaseReader: ValueReader[LiquibaseConfig] = ValueReader.relative { config =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
@@ -21,6 +21,7 @@ import com.google.api.services.compute.model.{Firewall, Instance}
 import com.google.api.services.compute.{Compute, ComputeScopes}
 import com.google.api.services.dataproc.Dataproc
 import com.google.api.services.dataproc.model.{Cluster => DataprocCluster, Operation => DataprocOperation, _}
+import com.google.api.services.oauth2.Oauth2Scopes
 import com.google.api.services.plus.PlusScopes
 import com.google.api.services.storage.model.Bucket.Lifecycle
 import com.google.api.services.storage.model.Bucket.Lifecycle.Rule.{Action, Condition}
@@ -30,7 +31,7 @@ import org.broadinstitute.dsde.workbench.google.GoogleUtilities
 import org.broadinstitute.dsde.workbench.google.gcs.{GcsBucketName, GcsPath, GcsRelativePath}
 import org.broadinstitute.dsde.workbench.leonardo.config.{ClusterResourcesConfig, DataprocConfig, ProxyConfig}
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterStatus.{ClusterStatus => LeoClusterStatus}
-import org.broadinstitute.dsde.workbench.leonardo.model.{Cluster => LeoCluster, ClusterErrorDetails, ClusterName, ClusterRequest, FirewallRuleName, GoogleProject, IP, InstanceName, LeoException, OperationName, ZoneUri, ClusterStatus => LeoClusterStatus}
+import org.broadinstitute.dsde.workbench.leonardo.model.{ClusterErrorDetails, ClusterName, ClusterRequest, FirewallRuleName, GoogleProject, IP, InstanceName, LeoException, OperationName, ZoneUri, Cluster => LeoCluster, ClusterStatus => LeoClusterStatus}
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 
 import scala.collection.JavaConverters._
@@ -55,6 +56,7 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig, protected 
   private lazy val cloudPlatformScopes = List(ComputeScopes.CLOUD_PLATFORM)
   private lazy val storageScopes = List(StorageScopes.DEVSTORAGE_FULL_CONTROL, ComputeScopes.COMPUTE, PlusScopes.USERINFO_EMAIL, PlusScopes.USERINFO_PROFILE)
   private lazy val vmScopes = List(ComputeScopes.COMPUTE, ComputeScopes.CLOUD_PLATFORM)
+  private lazy val oauth2Scopes = List(Oauth2Scopes.USERINFO_EMAIL, Oauth2Scopes.USERINFO_PROFILE)
   private lazy val serviceAccountPemFile = new File(clusterResourcesConfig.configFolderPath, clusterResourcesConfig.leonardoServicePem)
 
   private lazy val dataproc = {
@@ -111,6 +113,7 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig, protected 
     //   Set the network tag, which is needed by the firewall rule that allows leo to talk to the cluster
     val gce = new GceClusterConfig()
       .setServiceAccount(clusterRequest.serviceAccount.string)
+      .setServiceAccountScopes(oauth2Scopes.asJava)
       .setTags(List(proxyConfig.networkTag).asJava)
 
     // Create a NodeInitializationAction, which specifies the executable to run on a node.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/model/LeonardoModel.scala
@@ -133,8 +133,7 @@ object ClusterInitValues {
       dataprocConfig.jupyterServerName,
       proxyConfig.proxyServerName,
       GcsPath(bucketName, GcsRelativePath(clusterResourcesConfig.jupyterInstallExtensionScript)).toUri,
-      clusterRequest.jupyterExtensionUri.map(_.toUri).getOrElse(""),
-      GcsPath(bucketName, GcsRelativePath(clusterResourcesConfig.userServiceAccountCredentials)).toUri
+      clusterRequest.jupyterExtensionUri.map(_.toUri).getOrElse("")
     )
 }
 
@@ -152,8 +151,7 @@ case class ClusterInitValues(googleProject: String,
                              jupyterServerName: String,
                              proxyServerName: String,
                              jupyterInstallExtensionScript: String,
-                             jupyterExtensionUri: String,
-                             userServiceAccountCredentialsUri: String)
+                             jupyterExtensionUri: String)
 
 
 object FirewallRuleRequest {
@@ -253,6 +251,6 @@ object LeonardoJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val clusterFormat = jsonFormat13(Cluster.apply)
   implicit val clusterRequestFormat = jsonFormat4(ClusterRequest)
-  implicit val clusterInitValuesFormat = jsonFormat14(ClusterInitValues.apply)
+  implicit val clusterInitValuesFormat = jsonFormat13(ClusterInitValues.apply)
   implicit val defaultLabelsFormat = jsonFormat5(DefaultLabels.apply)
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoService.scala
@@ -169,8 +169,7 @@ class LeonardoService(protected val dataprocConfig: DataprocConfig, protected va
   private[service] def initializeBucketObjects(googleProject: GoogleProject, clusterName: ClusterName, bucketName: GcsBucketName, clusterRequest: ClusterRequest): Future[Unit] = {
     val replacements = ClusterInitValues(googleProject, clusterName, bucketName, clusterRequest, dataprocConfig, clusterResourcesConfig, proxyConfig).toJson.asJsObject.fields
     val filesToUpload = List(clusterResourcesConfig.jupyterServerCrt, clusterResourcesConfig.jupyterServerKey, clusterResourcesConfig.jupyterRootCaPem,
-      clusterResourcesConfig.clusterDockerCompose, clusterResourcesConfig.jupyterProxySiteConf, clusterResourcesConfig.jupyterInstallExtensionScript,
-      clusterResourcesConfig.userServiceAccountCredentials)
+      clusterResourcesConfig.clusterDockerCompose, clusterResourcesConfig.jupyterProxySiteConf, clusterResourcesConfig.jupyterInstallExtensionScript)
 
     for {
       // Fill in templated fields in the init script with the given replacements

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -61,7 +61,6 @@ clusterResources {
   jupyterRootCaKey = "test.key"
   jupyterInstallExtensionScript = "install-jupyter-extension.sh"
   proxySiteConf = "site.conf"
-  userServiceAccountCredentials = "leo-demo-sa.json"
 }
 
 akka.ssl-config {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/service/LeonardoServiceSpec.scala
@@ -41,8 +41,8 @@ class LeonardoServiceSpec extends TestKit(ActorSystem("leonardotest")) with Flat
   }
 
   val initFiles = Array(clusterResourcesConfig.clusterDockerCompose, clusterResourcesConfig.initActionsScript, clusterResourcesConfig.jupyterServerCrt,
-    clusterResourcesConfig.jupyterServerKey, clusterResourcesConfig.jupyterRootCaPem, clusterResourcesConfig.jupyterProxySiteConf, clusterResourcesConfig.jupyterInstallExtensionScript,
-    clusterResourcesConfig.userServiceAccountCredentials) map GcsRelativePath
+    clusterResourcesConfig.jupyterServerKey, clusterResourcesConfig.jupyterRootCaPem, clusterResourcesConfig.jupyterProxySiteConf, clusterResourcesConfig.jupyterInstallExtensionScript
+  ) map GcsRelativePath
 
   "LeonardoService" should "create a cluster" in isolatedDbTest {
     // create the cluster


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5368863/31643108-a28c8b88-b2bc-11e7-9bbb-9acee2a2223a.png)

It turns out you can call `.setServiceAccountScopes()` at cluster creation time, and setting OAuth2Scopes lets the service account talk to FC without the local key json. (i.e. it has the right scopes on the metadata server.) Thanks to Josh Mandel for discovering this. This essentially resolves https://broadinstitute.atlassian.net/browse/GAWB-2649 and removes the need for https://broadinstitute.atlassian.net/browse/GAWB-2615.

I basically updated `GoogleDataprocDAO` to do this, and removed the existing code related to pushing the SA key to the init bucket & cluster. I verified locally creating a cluster and running the demo script.

PR friend: https://github.com/broadinstitute/firecloud-develop/pull/721

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
