### PR TITLE
Fix bug with cookie auth expiration

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/DataprocDAO.scala
@@ -1,8 +1,8 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import java.io.File
+import java.time.Instant
 
-import akka.http.scaladsl.model.DateTime
 import org.broadinstitute.dsde.workbench.google.gcs.{GcsBucketName, GcsPath}
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterStatus.{ClusterStatus => LeoClusterStatus}
 import org.broadinstitute.dsde.workbench.leonardo.model._
@@ -33,5 +33,5 @@ trait DataprocDAO {
 
   def deleteBucket(googleProject: GoogleProject, gcsBucketName: GcsBucketName)(implicit executionContext: ExecutionContext): Future[Unit]
 
-  def getEmailAndExpirationFromAccessToken(accessToken: String)(implicit executionContext: ExecutionContext): Future[(WorkbenchUserEmail, DateTime)]
+  def getEmailAndExpirationFromAccessToken(accessToken: String)(implicit executionContext: ExecutionContext): Future[(WorkbenchUserEmail, Instant)]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/dao/GoogleDataprocDAO.scala
@@ -2,10 +2,11 @@ package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import java.io.{ByteArrayInputStream, File}
 import java.nio.charset.StandardCharsets
+import java.time.Instant
 import java.util.UUID
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.{DateTime, StatusCodes}
+import akka.http.scaladsl.model.StatusCodes
 import cats.data.OptionT
 import cats.instances.future._
 import cats.syntax.functor._
@@ -97,9 +98,9 @@ class GoogleDataprocDAO(protected val dataprocConfig: DataprocConfig, protected 
   }
 
   // Using the given access token, look up the corresponding email of the user and get how long, in seconds, the token will expire in
-  def getEmailAndExpirationFromAccessToken(accessToken: String)(implicit executionContext: ExecutionContext): Future[(WorkbenchUserEmail, DateTime)] = {
+  def getEmailAndExpirationFromAccessToken(accessToken: String)(implicit executionContext: ExecutionContext): Future[(WorkbenchUserEmail, Instant)] = {
     val request = oauth2.tokeninfo().setAccessToken(accessToken)
-    executeGoogleRequestAsync(GoogleProject(""), "cookie auth", request).map{tokenInfo => (WorkbenchUserEmail(tokenInfo.getEmail), DateTime.now + tokenInfo.getExpiresIn.toInt)}
+    executeGoogleRequestAsync(GoogleProject(""), "cookie auth", request).map{tokenInfo => (WorkbenchUserEmail(tokenInfo.getEmail), Instant.now().plusSeconds(tokenInfo.getExpiresIn.toInt))}
         .recover { case CallToGoogleApiFailedException(_, _, _, _) => {
         logger.error(s"Unable to authorize token: $accessToken")
         throw AuthorizationError()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockGoogleDataprocDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/dao/MockGoogleDataprocDAO.scala
@@ -1,9 +1,9 @@
 package org.broadinstitute.dsde.workbench.leonardo.dao
 
 import java.io.File
+import java.time.Instant
 import java.util.UUID
 
-import akka.http.scaladsl.model.DateTime
 import org.broadinstitute.dsde.workbench.google.gcs.{GcsBucketName, GcsPath, GcsRelativePath}
 import org.broadinstitute.dsde.workbench.leonardo.config.{DataprocConfig, ProxyConfig}
 import org.broadinstitute.dsde.workbench.leonardo.model.ClusterStatus._
@@ -25,12 +25,12 @@ class MockGoogleDataprocDAO(protected val dataprocConfig: DataprocConfig, protec
 
   private def googleID = UUID.randomUUID()
 
-  def getEmailAndExpirationFromAccessToken(accessToken: String)(implicit executionContext: ExecutionContext): Future[(WorkbenchUserEmail, DateTime)] = {
+  override def getEmailAndExpirationFromAccessToken(accessToken: String)(implicit executionContext: ExecutionContext): Future[(WorkbenchUserEmail, Instant)] = {
     Future {
       accessToken match {
         case "unauthorized" => throw AuthorizationError()
-        case "expired" =>  (WorkbenchUserEmail("expiredUser@example.com"), DateTime.now - 10)
-        case _ => (WorkbenchUserEmail("user1@example.com"), DateTime.MaxValue)
+        case "expired" =>  (WorkbenchUserEmail("expiredUser@example.com"), Instant.now.minusSeconds(10))
+        case _ => (WorkbenchUserEmail("user1@example.com"), Instant.MAX)
       }
     }
   }


### PR DESCRIPTION
I found this issue while testing pet service accounts. The Google auth tokenInfo.expiresIn was being treated as milliseconds rather than seconds, causing tokens to prematurely expire.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've documented my API changes in Swagger

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
